### PR TITLE
Integrate an IGVM loader into QEMU

### DIFF
--- a/backends/confidential-guest-support.c
+++ b/backends/confidential-guest-support.c
@@ -20,8 +20,29 @@ OBJECT_DEFINE_ABSTRACT_TYPE(ConfidentialGuestSupport,
                             CONFIDENTIAL_GUEST_SUPPORT,
                             OBJECT)
 
+#if defined(CONFIG_IGVM)
+static char *get_igvm(Object *obj, Error **errp)
+{
+    ConfidentialGuestSupport *cgs = CONFIDENTIAL_GUEST_SUPPORT(obj);
+    return g_strdup(cgs->igvm_filename);
+}
+
+static void set_igvm(Object *obj, const char *value, Error **errp)
+{
+    ConfidentialGuestSupport *cgs = CONFIDENTIAL_GUEST_SUPPORT(obj);
+    g_free(cgs->igvm_filename);
+    cgs->igvm_filename = g_strdup(value);
+}
+#endif
+
 static void confidential_guest_support_class_init(ObjectClass *oc, void *data)
 {
+#if defined(CONFIG_IGVM)
+    object_class_property_add_str(oc, "igvm-file",
+        get_igvm, set_igvm);
+    object_class_property_set_description(oc, "igvm-file",
+        "Set the IGVM filename to use");
+#endif
 }
 
 static void confidential_guest_support_init(Object *obj)

--- a/backends/confidential-guest-support.c
+++ b/backends/confidential-guest-support.c
@@ -15,6 +15,7 @@
 
 #include "exec/confidential-guest-support.h"
 #include "qemu/error-report.h"
+#include "exec/igvm.h"
 
 OBJECT_DEFINE_ABSTRACT_TYPE(ConfidentialGuestSupport,
                             confidential_guest_support,
@@ -33,6 +34,9 @@ static void set_igvm(Object *obj, const char *value, Error **errp)
     ConfidentialGuestSupport *cgs = CONFIDENTIAL_GUEST_SUPPORT(obj);
     g_free(cgs->igvm_filename);
     cgs->igvm_filename = g_strdup(value);
+#if defined(CONFIG_IGVM)
+    igvm_file_init(cgs);
+#endif
 }
 #endif
 

--- a/backends/confidential-guest-support.c
+++ b/backends/confidential-guest-support.c
@@ -14,6 +14,7 @@
 #include "qemu/osdep.h"
 
 #include "exec/confidential-guest-support.h"
+#include "qemu/error-report.h"
 
 OBJECT_DEFINE_ABSTRACT_TYPE(ConfidentialGuestSupport,
                             confidential_guest_support,
@@ -45,8 +46,47 @@ static void confidential_guest_support_class_init(ObjectClass *oc, void *data)
 #endif
 }
 
+static int check_support(ConfidentialGuestPlatformType platform,
+                         uint16_t platform_version, uint8_t highest_vtl,
+                         uint64_t shared_gpa_boundary)
+{
+    /* Default: no support. */
+    return 0;
+}
+
+static int set_memory_attributes(hwaddr gpa, uint8_t *ptr, uint64_t len,
+                                 int memory_type)
+{
+    warn_report("Confidential guest memory attributes not supported");
+    return -1;
+}
+
+static int set_cpu_context(uint16_t cpu_index, const void *ctx,
+                           uint32_t ctx_len)
+{
+    warn_report("Confidential guest CPU context not supported");
+    return -1;
+}
+
+static int get_mem_map_count(void)
+{
+    return 0;
+}
+
+static void get_mem_map_entry(int index, ConfidentialGuestMemoryMapEntry *entry)
+{
+    error_report("Invalid memory map entry requested");
+    exit(EXIT_FAILURE);
+}
+
 static void confidential_guest_support_init(Object *obj)
 {
+    ConfidentialGuestSupport *cgs = CONFIDENTIAL_GUEST_SUPPORT(obj);
+    cgs->check_support = check_support;
+    cgs->set_memory_attributes = set_memory_attributes;
+    cgs->set_cpu_context = set_cpu_context;
+    cgs->get_mem_map_count = get_mem_map_count;
+    cgs->get_mem_map_entry = get_mem_map_entry;
 }
 
 static void confidential_guest_support_finalize(Object *obj)

--- a/backends/confidential-guest-support.c
+++ b/backends/confidential-guest-support.c
@@ -96,3 +96,21 @@ static void confidential_guest_support_init(Object *obj)
 static void confidential_guest_support_finalize(Object *obj)
 {
 }
+
+bool cgs_is_igvm(ConfidentialGuestSupport *cgs)
+{
+#if defined(CONFIG_IGVM)
+    return cgs && cgs->igvm;
+#else
+    return false;
+#endif
+}
+
+void cgs_process_igvm(ConfidentialGuestSupport *cgs)
+{
+#if defined(CONFIG_IGVM)
+    if (cgs && cgs_is_igvm(cgs)) {
+        igvm_process(cgs);
+    }
+#endif
+}

--- a/backends/igvm.c
+++ b/backends/igvm.c
@@ -1,0 +1,678 @@
+/*
+ * Copyright (c) 2023 SUSE
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 or later, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "qemu/osdep.h"
+
+#if defined(CONFIG_IGVM)
+
+#include "exec/confidential-guest-support.h"
+#include "qemu/queue.h"
+#include "qemu/typedefs.h"
+
+#include "exec/igvm.h"
+#include "qemu/error-report.h"
+#include "hw/boards.h"
+#include "qapi/error.h"
+#include "exec/address-spaces.h"
+
+#include <igvm/igvm.h>
+#include <igvm/igvm_defs.h>
+#include <linux/kvm.h>
+
+typedef struct IgvmParameterData {
+    QTAILQ_ENTRY(IgvmParameterData) next;
+    uint8_t *data;
+    uint32_t size;
+    uint32_t index;
+} IgvmParameterData;
+
+static QTAILQ_HEAD(, IgvmParameterData) parameter_data;
+
+static void directive_page_data(ConfidentialGuestSupport *cgs, int i,
+                                uint32_t compatibility_mask);
+static void directive_vp_context(ConfidentialGuestSupport *cgs, int i,
+                                 uint32_t compatibility_mask);
+static void directive_parameter_area(ConfidentialGuestSupport *cgs, int i,
+                                     uint32_t compatibility_mask);
+static void directive_parameter_insert(ConfidentialGuestSupport *cgs, int i,
+                                       uint32_t compatibility_mask);
+static void directive_memory_map(ConfidentialGuestSupport *cgs, int i,
+                                 uint32_t compatibility_mask);
+static void directive_vp_count(ConfidentialGuestSupport *cgs, int i,
+                               uint32_t compatibility_mask);
+static void directive_environment_info(ConfidentialGuestSupport *cgs, int i,
+                                       uint32_t compatibility_mask);
+static void directive_required_memory(ConfidentialGuestSupport *cgs, int i,
+                                      uint32_t compatibility_mask);
+
+struct IGVMDirectiveHandler {
+    uint32_t type;
+    void (*handler)(ConfidentialGuestSupport *cgs, int i,
+                    uint32_t compatibility_mask);
+};
+
+static struct IGVMDirectiveHandler directive_handlers[] = {
+    { IGVM_VHT_PAGE_DATA, directive_page_data },
+    { IGVM_VHT_VP_CONTEXT, directive_vp_context },
+    { IGVM_VHT_PARAMETER_AREA, directive_parameter_area },
+    { IGVM_VHT_PARAMETER_INSERT, directive_parameter_insert },
+    { IGVM_VHT_MEMORY_MAP, directive_memory_map },
+    { IGVM_VHT_VP_COUNT_PARAMETER, directive_vp_count },
+    { IGVM_VHT_ENVIRONMENT_INFO_PARAMETER, directive_environment_info },
+    { IGVM_VHT_REQUIRED_MEMORY, directive_required_memory },
+};
+
+static void directive(uint32_t type, ConfidentialGuestSupport *cgs, int i,
+                      uint32_t compatibility_mask)
+{
+    size_t handler;
+    for (handler = 0; handler < (sizeof(directive_handlers) /
+                                 sizeof(struct IGVMDirectiveHandler));
+         ++handler) {
+        if (directive_handlers[handler].type == type) {
+            directive_handlers[handler].handler(cgs, i, compatibility_mask);
+            return;
+        }
+    }
+    warn_report("IGVM: Unknown directive encountered when processing file: %X",
+                type);
+}
+
+static void igvm_handle_error(int32_t result, const char *msg)
+{
+    if (result < 0) {
+        error_report("Processing of IGVM file failed: %s (code: %d)", msg,
+                     (int)result);
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void *igvm_prepare_memory(uint64_t addr, uint64_t size)
+{
+    MemoryRegion *igvm_pages = NULL;
+    Int128 gpa_region_size;
+    MemoryRegionSection mrs =
+        memory_region_find(get_system_memory(), addr, size);
+    if (mrs.mr) {
+        if (!memory_region_is_ram(mrs.mr)) {
+            memory_region_unref(mrs.mr);
+            error_report(
+                "Processing of IGVM file failed: Could not prepare memory "
+                "at address 0x%lX due to existing non-RAM region",
+                addr);
+            exit(EXIT_FAILURE);
+        }
+
+        gpa_region_size = int128_make64(size);
+        if (int128_lt(mrs.size, gpa_region_size)) {
+            memory_region_unref(mrs.mr);
+            error_report(
+                "Processing of IGVM file failed: Could not prepare memory "
+                "at address 0x%lX: region size exceeded",
+                addr);
+            exit(EXIT_FAILURE);
+        }
+        return qemu_map_ram_ptr(mrs.mr->ram_block, mrs.offset_within_region);
+    } else {
+        igvm_pages = g_malloc(sizeof(*igvm_pages));
+        memory_region_init_ram(igvm_pages, NULL, "igvm.pages", size,
+                               &error_fatal);
+        memory_region_add_subregion(get_system_memory(), addr, igvm_pages);
+        return memory_region_get_ram_ptr(igvm_pages);
+    }
+}
+
+static int igvm_type_to_kvm_type(IgvmPageDataType memory_type, bool unmeasured,
+                                 bool zero)
+{
+    switch (memory_type) {
+    case NORMAL: {
+        if (unmeasured) {
+            return KVM_SEV_SNP_PAGE_TYPE_UNMEASURED;
+        } else {
+            return zero ? KVM_SEV_SNP_PAGE_TYPE_ZERO :
+                          KVM_SEV_SNP_PAGE_TYPE_NORMAL;
+        }
+    }
+    case SECRETS:
+        return KVM_SEV_SNP_PAGE_TYPE_SECRETS;
+    case CPUID_DATA:
+        return KVM_SEV_SNP_PAGE_TYPE_CPUID;
+    case CPUID_XF:
+        return KVM_SEV_SNP_PAGE_TYPE_CPUID;
+    default:
+        return KVM_SEV_SNP_PAGE_TYPE_UNMEASURED;
+    }
+}
+
+static bool page_attrs_equal(const IGVM_VHS_PAGE_DATA *page_1,
+                             const IGVM_VHS_PAGE_DATA *page_2)
+{
+    return ((*(const uint32_t *)&page_1->flags ==
+             *(const uint32_t *)&page_2->flags) &&
+            (page_1->data_type == page_2->data_type) &&
+            (page_1->compatibility_mask == page_2->compatibility_mask));
+}
+
+static void igvm_process_mem_region(ConfidentialGuestSupport *cgs,
+                                    IgvmHandle igvm, int start_index,
+                                    uint64_t gpa_start, int page_count,
+                                    const IgvmPageDataFlags *flags,
+                                    const IgvmPageDataType page_type)
+{
+    uint8_t *region;
+    IgvmHandle data_handle;
+    const void *data;
+    uint32_t data_size;
+    int i;
+    bool zero = true;
+    const uint64_t page_size = flags->is_2mb_page ? 0x200000 : 0x1000;
+    int result;
+
+    region = igvm_prepare_memory(gpa_start, page_count * page_size);
+
+    for (i = 0; i < page_count; ++i) {
+        data_handle = igvm_get_header_data(igvm, HEADER_SECTION_DIRECTIVE,
+                                           i + start_index);
+        if (data_handle == IGVMAPI_NO_DATA) {
+            /* No data indicates a zero page */
+            memset(&region[i * page_size], 0, page_size);
+        } else if (data_handle < 0) {
+            igvm_handle_error(data_handle, "Invalid file");
+        } else {
+            zero = false;
+            data = igvm_get_buffer(igvm, data_handle);
+            data_size = igvm_get_buffer_size(igvm, data_handle);
+            if (data_size < page_size) {
+                memset(&region[i * page_size], 0, page_size);
+            } else if (data_size > page_size) {
+                igvm_handle_error(data_handle, "Invalid page data in file");
+            }
+            memcpy(&region[i * page_size], data, data_size);
+            igvm_free_buffer(igvm, data_handle);
+        }
+    }
+
+    result = cgs->set_memory_attributes(
+        gpa_start, region, page_size * page_count,
+        igvm_type_to_kvm_type(page_type, flags->unmeasured, zero));
+    if (result != 0) {
+        error_report("IGVM memory attributes failed with code %d", result);
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void process_mem_page(ConfidentialGuestSupport *cgs, int i,
+                             const IGVM_VHS_PAGE_DATA *page_data)
+{
+    static IGVM_VHS_PAGE_DATA prev_page_data;
+    static uint64_t region_start;
+    static int last_i;
+    static int page_count = 0;
+
+    if (page_data) {
+        if (page_count == 0) {
+            region_start = page_data->gpa;
+        } else {
+            if (!page_attrs_equal(page_data, &prev_page_data) ||
+                ((prev_page_data.gpa +
+                  (prev_page_data.flags.is_2mb_page ? 0x200000 : 0x1000)) !=
+                 page_data->gpa) ||
+                (last_i != (i - 1))) {
+                /* End of current region */
+                igvm_process_mem_region(cgs, cgs->igvm, i - page_count,
+                                        region_start, page_count,
+                                        &prev_page_data.flags,
+                                        prev_page_data.data_type);
+                page_count = 0;
+                region_start = page_data->gpa;
+            }
+        }
+        memcpy(&prev_page_data, page_data, sizeof(prev_page_data));
+        last_i = i;
+        ++page_count;
+    } else {
+        if (page_count > 0) {
+            igvm_process_mem_region(cgs, cgs->igvm, i - page_count,
+                                    region_start, page_count,
+                                    &prev_page_data.flags,
+                                    prev_page_data.data_type);
+            page_count = 0;
+        }
+    }
+}
+
+static void directive_page_data(ConfidentialGuestSupport *cgs, int i,
+                                uint32_t compatibility_mask)
+{
+    IgvmHandle header_handle;
+    const IGVM_VHS_PAGE_DATA *page_data;
+
+    header_handle = igvm_get_header(cgs->igvm, HEADER_SECTION_DIRECTIVE, i);
+    igvm_handle_error(header_handle,
+                      "Failed to read directive header from file");
+    page_data =
+        (IGVM_VHS_PAGE_DATA *)(igvm_get_buffer(cgs->igvm, header_handle) +
+                               sizeof(IGVM_VHS_VARIABLE_HEADER));
+
+    if (page_data->compatibility_mask == compatibility_mask) {
+        process_mem_page(cgs, i, page_data);
+    }
+    igvm_free_buffer(cgs->igvm, header_handle);
+}
+
+static void directive_vp_context(ConfidentialGuestSupport *cgs, int i,
+                                 uint32_t compatibility_mask)
+{
+    IgvmHandle header_handle;
+    IGVM_VHS_VP_CONTEXT *vp_context;
+    IgvmHandle data_handle;
+    const void *data;
+
+    header_handle = igvm_get_header(cgs->igvm, HEADER_SECTION_DIRECTIVE, i);
+    igvm_handle_error(header_handle,
+                      "Failed to read directive header from file");
+    vp_context =
+        (IGVM_VHS_VP_CONTEXT *)(igvm_get_buffer(cgs->igvm, header_handle) +
+                                sizeof(IGVM_VHS_VARIABLE_HEADER));
+
+    if (vp_context->compatibility_mask == compatibility_mask) {
+        data_handle =
+            igvm_get_header_data(cgs->igvm, HEADER_SECTION_DIRECTIVE, i);
+        igvm_handle_error(data_handle,
+                          "Failed to read directive data from file");
+
+        data = igvm_get_buffer(cgs->igvm, data_handle);
+        cgs->set_cpu_context(vp_context->vp_index, data,
+                             igvm_get_buffer_size(cgs->igvm, data_handle));
+        igvm_free_buffer(cgs->igvm, data_handle);
+    }
+
+    igvm_free_buffer(cgs->igvm, header_handle);
+}
+
+static void directive_parameter_area(ConfidentialGuestSupport *cgs, int i,
+                                     uint32_t compatibility_mask)
+{
+    IgvmHandle header_handle;
+    IGVM_VHS_PARAMETER_AREA *param_area;
+    IgvmParameterData *param_entry;
+
+    header_handle = igvm_get_header(cgs->igvm, HEADER_SECTION_DIRECTIVE, i);
+    igvm_handle_error(header_handle,
+                      "Failed to read directive header from file");
+    param_area =
+        (IGVM_VHS_PARAMETER_AREA *)(igvm_get_buffer(cgs->igvm, header_handle) +
+                                    sizeof(IGVM_VHS_VARIABLE_HEADER));
+
+    param_entry = g_new0(IgvmParameterData, 1);
+    param_entry->size = param_area->number_of_bytes;
+    param_entry->index = param_area->parameter_area_index;
+    param_entry->data = g_malloc0(param_entry->size);
+
+    QTAILQ_INSERT_TAIL(&parameter_data, param_entry, next);
+
+    igvm_free_buffer(cgs->igvm, header_handle);
+}
+
+static void directive_parameter_insert(ConfidentialGuestSupport *cgs, int i,
+                                       uint32_t compatibility_mask)
+{
+    IgvmHandle header_handle;
+    IGVM_VHS_PARAMETER_INSERT *param;
+    IgvmParameterData *param_entry;
+    int result;
+    void *region;
+
+    header_handle = igvm_get_header(cgs->igvm, HEADER_SECTION_DIRECTIVE, i);
+    igvm_handle_error(header_handle,
+                      "Failed to read directive header from file");
+    param = (IGVM_VHS_PARAMETER_INSERT *)(igvm_get_buffer(cgs->igvm,
+                                                          header_handle) +
+                                          sizeof(IGVM_VHS_VARIABLE_HEADER));
+
+    QTAILQ_FOREACH(param_entry, &parameter_data, next)
+    {
+        if (param_entry->index == param->parameter_area_index) {
+            region = igvm_prepare_memory(param->gpa, param_entry->size);
+            if (!region) {
+                error_report(
+                    "IGVM: Failed to allocate guest memory region for parameters");
+                exit(EXIT_FAILURE);
+            }
+            memcpy(region, param_entry->data, param_entry->size);
+            g_free(param_entry->data);
+            param_entry->data = NULL;
+
+            result = cgs->set_memory_attributes(param->gpa, region,
+                                                param_entry->size,
+                                                KVM_SEV_SNP_PAGE_TYPE_NORMAL);
+            if (result != 0) {
+                error_report(
+                    "IGVM: Failed to set memory attributes: error_code=%d",
+                    result);
+                exit(EXIT_FAILURE);
+            }
+            break;
+        }
+    }
+}
+
+static int cmp_mm_entry(const void *a, const void *b)
+{
+    uint64_t gpa1 =
+        ((const IGVM_VHS_MEMORY_MAP_ENTRY *)a)->starting_gpa_page_number;
+    uint64_t gpa2 =
+        ((const IGVM_VHS_MEMORY_MAP_ENTRY *)b)->starting_gpa_page_number;
+    if (gpa1 < gpa2) {
+        return -1;
+    } else if (gpa1 > gpa2) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+static void directive_memory_map(ConfidentialGuestSupport *cgs, int i,
+                                 uint32_t compatibility_mask)
+{
+    IgvmHandle header_handle;
+    IGVM_VHS_PARAMETER *param;
+    IgvmParameterData *param_entry;
+    size_t entry_count;
+    size_t entry;
+    IGVM_VHS_MEMORY_MAP_ENTRY *mm_entry;
+    ConfidentialGuestMemoryMapEntry cgmm_entry;
+
+    header_handle = igvm_get_header(cgs->igvm, HEADER_SECTION_DIRECTIVE, i);
+    igvm_handle_error(header_handle,
+                      "Failed to read directive header from file");
+    param = (IGVM_VHS_PARAMETER *)(igvm_get_buffer(cgs->igvm, header_handle) +
+                                   sizeof(IGVM_VHS_VARIABLE_HEADER));
+
+    /* Find the parameter area that should hold the memory map */
+    QTAILQ_FOREACH(param_entry, &parameter_data, next)
+    {
+        if (param_entry->index == param->parameter_area_index) {
+            entry_count = cgs->get_mem_map_count();
+            if ((entry_count * sizeof(IGVM_VHS_MEMORY_MAP_ENTRY)) >
+                param_entry->size) {
+                error_report(
+                    "IGVM: guest memory map size exceeds parameter area defined in IGVM file");
+                exit(EXIT_FAILURE);
+            }
+            mm_entry = (IGVM_VHS_MEMORY_MAP_ENTRY *)param_entry->data;
+
+            for (entry = 0; entry < entry_count; ++entry) {
+                cgs->get_mem_map_entry(entry, &cgmm_entry);
+                mm_entry[entry].starting_gpa_page_number = cgmm_entry.gpa >> 12;
+                mm_entry[entry].number_of_pages = cgmm_entry.size >> 12;
+
+                switch (cgmm_entry.type) {
+                case CGS_MEM_RAM:
+                    mm_entry[entry].entry_type = MEMORY;
+                    break;
+                case CGS_MEM_RESERVED:
+                    mm_entry[entry].entry_type = PLATFORM_RESERVED;
+                    break;
+                case CGS_MEM_ACPI:
+                    mm_entry[entry].entry_type = PLATFORM_RESERVED;
+                    break;
+                case CGS_MEM_NVS:
+                    mm_entry[entry].entry_type = PERSISTENT;
+                    break;
+                case CGS_MEM_UNUSABLE:
+                    mm_entry[entry].entry_type = PLATFORM_RESERVED;
+                    break;
+                }
+            }
+            // The entries need to be sorted
+            qsort(mm_entry, entry_count, sizeof(IGVM_VHS_MEMORY_MAP_ENTRY),
+                  cmp_mm_entry);
+
+            break;
+        }
+    }
+
+    igvm_free_buffer(cgs->igvm, header_handle);
+}
+
+static void directive_vp_count(ConfidentialGuestSupport *cgs, int i,
+                               uint32_t compatibility_mask)
+{
+    IgvmHandle header_handle;
+    IGVM_VHS_PARAMETER *param;
+    IgvmParameterData *param_entry;
+    uint32_t *vp_count;
+    CPUState *cpu;
+
+    header_handle = igvm_get_header(cgs->igvm, HEADER_SECTION_DIRECTIVE, i);
+    igvm_handle_error(header_handle,
+                      "Failed to read directive header from file");
+    param = (IGVM_VHS_PARAMETER *)(igvm_get_buffer(cgs->igvm, header_handle) +
+                                   sizeof(IGVM_VHS_VARIABLE_HEADER));
+
+    QTAILQ_FOREACH(param_entry, &parameter_data, next)
+    {
+        if (param_entry->index == param->parameter_area_index) {
+            vp_count = (uint32_t *)(param_entry->data + param->byte_offset);
+            *vp_count = 0;
+            CPU_FOREACH(cpu)
+            {
+                (*vp_count)++;
+            }
+            break;
+        }
+    }
+
+    igvm_free_buffer(cgs->igvm, header_handle);
+}
+
+static void directive_environment_info(ConfidentialGuestSupport *cgs, int i,
+                                       uint32_t compatibility_mask)
+{
+    IgvmHandle header_handle;
+    IGVM_VHS_PARAMETER *param;
+    IgvmParameterData *param_entry;
+    IgvmEnvironmentInfo *environmental_state;
+
+    header_handle = igvm_get_header(cgs->igvm, HEADER_SECTION_DIRECTIVE, i);
+    igvm_handle_error(header_handle,
+                      "Failed to read directive header from file");
+    param = (IGVM_VHS_PARAMETER *)(igvm_get_buffer(cgs->igvm, header_handle) +
+                                   sizeof(IGVM_VHS_VARIABLE_HEADER));
+
+    QTAILQ_FOREACH(param_entry, &parameter_data, next)
+    {
+        if (param_entry->index == param->parameter_area_index) {
+            environmental_state =
+                (IgvmEnvironmentInfo *)(param_entry->data + param->byte_offset);
+            environmental_state->memory_is_shared = 1;
+            break;
+        }
+    }
+
+    igvm_free_buffer(cgs->igvm, header_handle);
+}
+
+static void directive_required_memory(ConfidentialGuestSupport *cgs, int i,
+                                      uint32_t compatibility_mask)
+{
+    IgvmHandle header_handle;
+    const IGVM_VHS_REQUIRED_MEMORY *mem;
+    uint8_t *region;
+    int result;
+
+    header_handle = igvm_get_header(cgs->igvm, HEADER_SECTION_DIRECTIVE, i);
+    igvm_handle_error(header_handle,
+                      "Failed to read directive header from file");
+    mem =
+        (IGVM_VHS_REQUIRED_MEMORY *)(igvm_get_buffer(cgs->igvm, header_handle) +
+                                     sizeof(IGVM_VHS_VARIABLE_HEADER));
+
+    if (mem->compatibility_mask == compatibility_mask) {
+        region = igvm_prepare_memory(mem->gpa, mem->number_of_bytes);
+        result = cgs->set_memory_attributes(mem->gpa, region,
+                                            mem->number_of_bytes,
+                                            KVM_SEV_SNP_PAGE_TYPE_UNMEASURED);
+        if (result != 0) {
+            error_report("IGVM: Failed to set memory attributes: error_code=%d",
+                         result);
+            exit(EXIT_FAILURE);
+        }
+    }
+    igvm_free_buffer(cgs->igvm, header_handle);
+}
+
+static uint32_t supported_platform_compat_mask(ConfidentialGuestSupport *cgs)
+{
+    int32_t result;
+    int i;
+    IgvmHandle header_handle;
+    IGVM_VHS_SUPPORTED_PLATFORM *platform;
+    uint32_t compatibility_mask = 0;
+
+    result = igvm_header_count(cgs->igvm, HEADER_SECTION_PLATFORM);
+    igvm_handle_error(result, "Failed to read platform header count");
+
+    for (i = 0; i < (int)result; ++i) {
+        IgvmVariableHeaderType typ =
+            igvm_get_header_type(cgs->igvm, HEADER_SECTION_PLATFORM, i);
+        if (typ == IGVM_VHT_SUPPORTED_PLATFORM) {
+            header_handle =
+                igvm_get_header(cgs->igvm, HEADER_SECTION_PLATFORM, i);
+            igvm_handle_error(header_handle,
+                              "Failed to read platform header from file");
+            platform =
+                (IGVM_VHS_SUPPORTED_PLATFORM *)(igvm_get_buffer(cgs->igvm,
+                                                                header_handle) +
+                                                sizeof(
+                                                    IGVM_VHS_VARIABLE_HEADER));
+            /* Currently only support SEV-SNP. */
+            if (platform->platform_type == SEV_SNP) {
+                if (cgs->check_support(CGS_SEV_SNP, platform->platform_version,
+                                       platform->highest_vtl,
+                                       platform->shared_gpa_boundary)) {
+                    compatibility_mask = platform->compatibility_mask;
+                    break;
+                }
+            }
+            igvm_free_buffer(cgs->igvm, header_handle);
+        }
+    }
+    return compatibility_mask;
+}
+
+void igvm_file_init(ConfidentialGuestSupport *cgs)
+{
+    FILE *igvm_file = NULL;
+    uint8_t *igvm_buf = NULL;
+
+    if (cgs->igvm_filename) {
+        IgvmHandle igvm;
+        unsigned long igvm_length;
+
+        FILE *igvm_file = fopen(cgs->igvm_filename, "rb");
+        if (!igvm_file) {
+            error_report("IGVM file not found '%s'", cgs->igvm_filename);
+            goto error_out;
+        }
+
+        fseek(igvm_file, 0, SEEK_END);
+        igvm_length = ftell(igvm_file);
+        fseek(igvm_file, 0, SEEK_SET);
+
+        igvm_buf = (uint8_t *)g_malloc(igvm_length);
+        if (!igvm_buf) {
+            error_report(
+                "Could not allocate buffer to read file IGVM file '%s'",
+                cgs->igvm_filename);
+            goto error_out;
+        }
+        if (fread(igvm_buf, 1, igvm_length, igvm_file) != igvm_length) {
+            error_report("Unable to load IGVM file '%s'", cgs->igvm_filename);
+            goto error_out;
+        }
+
+        if ((igvm = igvm_new_from_binary(igvm_buf, igvm_length)) < 0) {
+            error_report("Parsing IGVM file '%s' failed with  error_code %d",
+                         cgs->igvm_filename, igvm);
+            goto error_out;
+        }
+        fclose(igvm_file);
+        g_free(igvm_buf);
+
+        cgs->igvm = igvm;
+    }
+    return;
+
+error_out:
+    free(igvm_buf);
+    if (igvm_file) {
+        fclose(igvm_file);
+    }
+    exit(EXIT_FAILURE);
+}
+
+void igvm_process(ConfidentialGuestSupport *cgs)
+{
+    int32_t result;
+    int i;
+    uint32_t compatibility_mask;
+    IgvmParameterData *parameter;
+
+    /*
+     * If this is not a Confidential guest or no IGVM has been provided then
+     * this is a no-op.
+     */
+    if (!cgs || !cgs->igvm) {
+        return;
+    }
+
+    QTAILQ_INIT(&parameter_data);
+
+    /* Check that the IGVM file provides configuration for the current platform */
+    compatibility_mask = supported_platform_compat_mask(cgs);
+    if (compatibility_mask == 0) {
+        error_report(
+            "IGVM file does not describe a compatible supported platform");
+        exit(EXIT_FAILURE);
+    }
+
+    result = igvm_header_count(cgs->igvm, HEADER_SECTION_DIRECTIVE);
+    igvm_handle_error(result, "Failed to read directive header count");
+    for (i = 0; i < (int)result; ++i) {
+        IgvmVariableHeaderType type =
+            igvm_get_header_type(cgs->igvm, HEADER_SECTION_DIRECTIVE, i);
+        directive(type, cgs, i, compatibility_mask);
+    }
+
+    /*
+     * Contiguous pages of data with compatible flags are grouped together in order
+     * to reduce the number of memory regions we create. Make sure the last group is
+     * processed with this call.
+     */
+    process_mem_page(cgs, i, NULL);
+
+    QTAILQ_FOREACH(parameter, &parameter_data, next)
+    {
+        if (parameter->data) {
+            g_free(parameter->data);
+            parameter->data = NULL;
+        }
+    }
+}
+
+#endif

--- a/backends/meson.build
+++ b/backends/meson.build
@@ -28,6 +28,7 @@ softmmu_ss.add(when: gio, if_true: files('dbus-vmstate.c'))
 softmmu_ss.add(when: 'CONFIG_SGX', if_true: files('hostmem-epc.c'))
 if igvm.found()
   softmmu_ss.add(igvm)
+  softmmu_ss.add(files('igvm.c'))
 endif
 
 subdir('tpm')

--- a/backends/meson.build
+++ b/backends/meson.build
@@ -26,5 +26,8 @@ if have_vhost_user_crypto
 endif
 softmmu_ss.add(when: gio, if_true: files('dbus-vmstate.c'))
 softmmu_ss.add(when: 'CONFIG_SGX', if_true: files('hostmem-epc.c'))
+if igvm.found()
+  softmmu_ss.add(igvm)
+endif
 
 subdir('tpm')

--- a/hw/i386/pc_piix.c
+++ b/hw/i386/pc_piix.c
@@ -67,6 +67,7 @@
 #include "hw/mem/nvdimm.h"
 #include "hw/i386/acpi-build.h"
 #include "kvm/kvm-cpu.h"
+#include "exec/confidential-guest-support.h"
 
 #define MAX_IDE_BUS 2
 
@@ -340,6 +341,9 @@ static void pc_init1(MachineState *machine,
                                x86_nvdimm_acpi_dsmio,
                                x86ms->fw_cfg, OBJECT(pcms));
     }
+
+    /* Apply confidential guest state from IGVM if supplied */
+    cgs_process_igvm(machine->cgs);
 }
 
 /* Looking for a pc_compat_2_4() function? It doesn't exist.

--- a/hw/i386/pc_q35.c
+++ b/hw/i386/pc_q35.c
@@ -56,6 +56,7 @@
 #include "hw/hyperv/vmbus-bridge.h"
 #include "hw/mem/nvdimm.h"
 #include "hw/i386/acpi-build.h"
+#include "exec/confidential-guest-support.h"
 
 /* ICH9 AHCI has 6 ports */
 #define MAX_SATA_PORTS     6
@@ -338,6 +339,9 @@ static void pc_q35_init(MachineState *machine)
                                x86_nvdimm_acpi_dsmio,
                                x86ms->fw_cfg, OBJECT(pcms));
     }
+
+    /* Apply confidential guest state from IGVM if supplied */
+    cgs_process_igvm(machine->cgs);
 }
 
 #define DEFINE_Q35_MACHINE(suffix, name, compatfn, optionfn) \

--- a/include/exec/confidential-guest-support.h
+++ b/include/exec/confidential-guest-support.h
@@ -52,6 +52,16 @@ struct ConfidentialGuestSupport {
      */
     bool ready;
     int discard;
+
+#if defined(CONFIG_IGVM)
+    /*
+     * igvm_filename: Optional filename that specifies a file that contains
+     *                the configuration of the guest in Isolated Guest 
+     *                Virtual Machine (IGVM) format.
+     */
+    char *igvm_filename;
+#endif
+
 };
 
 typedef struct ConfidentialGuestSupportClass {

--- a/include/exec/confidential-guest-support.h
+++ b/include/exec/confidential-guest-support.h
@@ -136,6 +136,23 @@ typedef struct ConfidentialGuestSupportClass {
     ObjectClass parent;
 } ConfidentialGuestSupportClass;
 
+/*
+ * Check whether the configuration of the confidential guest is provided
+ * using an IGVM file. IGVM configuration can include the system firmware,
+ * initial CPU state and other configuration that should override standard
+ * system initialization. This function should be used by platforms to 
+ * determine which devices and configuration to include during system
+ * initialization.
+ */
+bool cgs_is_igvm(ConfidentialGuestSupport *cgs);
+/*
+ * If IGVM is supported and an IGVM file has been specified then the
+ * configuration described in the file is applied to the guest.
+ * Configuration of a confidential guest includes the layout of the
+ * guest memory, including firmware and initial CPU state.
+ */
+void cgs_process_igvm(ConfidentialGuestSupport *cgs);
+
 #endif /* !CONFIG_USER_ONLY */
 
 #endif /* QEMU_CONFIDENTIAL_GUEST_SUPPORT_H */

--- a/include/exec/confidential-guest-support.h
+++ b/include/exec/confidential-guest-support.h
@@ -21,9 +21,32 @@
 #ifndef CONFIG_USER_ONLY
 
 #include "qom/object.h"
+#include "exec/hwaddr.h"
+
+#if defined(CONFIG_IGVM)
+#include "igvm/igvm.h"
+#endif
 
 #define TYPE_CONFIDENTIAL_GUEST_SUPPORT "confidential-guest-support"
 OBJECT_DECLARE_SIMPLE_TYPE(ConfidentialGuestSupport, CONFIDENTIAL_GUEST_SUPPORT)
+
+typedef enum ConfidentialGuestPlatformType {
+    CGS_SEV_SNP
+} ConfidentialGuestPlatformType;
+
+typedef enum ConfidentialGuestMemoryType {
+    CGS_MEM_RAM,
+    CGS_MEM_RESERVED,
+    CGS_MEM_ACPI,
+    CGS_MEM_NVS,
+    CGS_MEM_UNUSABLE,
+} ConfidentialGuestMemoryType;
+
+typedef struct ConfidentialGuestMemoryMapEntry {
+    uint64_t gpa;
+    uint64_t size;
+    ConfidentialGuestMemoryType type;
+} ConfidentialGuestMemoryMapEntry;
 
 struct ConfidentialGuestSupport {
     Object parent;
@@ -62,6 +85,46 @@ struct ConfidentialGuestSupport {
     char *igvm_filename;
 #endif
 
+    /*
+     * The following virtual methods need to be implemented by systems that
+     * support confidential guests that can be configured with IGVM and are
+     * used during processing of the IGVM file with process_igvm().
+     */
+
+    /*
+     * Check for to see if this confidential guest supports a particular
+     * platform or configuration
+     */
+    int (*check_support)(ConfidentialGuestPlatformType platform,
+                         uint16_t platform_version, uint8_t highest_vtl,
+                         uint64_t shared_gpa_boundary);
+
+    /* 
+     * Configure an area of guest memory, populating the guest memory with
+     * with the data in the provided pointer at the requested guest physical
+     * address. Memory type is one of KVM_SEV_SNP_PAGE_TYPE_*.
+     */
+    int (*set_memory_attributes)(hwaddr gpa, uint8_t *ptr, uint64_t len,
+                                 int memory_type);
+
+    /*
+     * Set the initial context for a virtual CPU. The format of the context pointed
+     * to by ctx depends on the type of confidential virtual machine. For example,
+     * for SEV-SNP, ctx points to a vmcb_save_area structure.
+     */
+    int (*set_cpu_context)(uint16_t cpu_index, const void *ctx,
+                           uint32_t ctx_len);
+
+    /*
+     * Get the number of entries that should be populated into the guest memory map.
+     */
+    int (*get_mem_map_count)(void);
+
+    /*
+     * Get an entry that should be populated in the guest memory map.
+     */
+    void (*get_mem_map_entry)(int index,
+                              ConfidentialGuestMemoryMapEntry *entry);
 };
 
 typedef struct ConfidentialGuestSupportClass {

--- a/include/exec/confidential-guest-support.h
+++ b/include/exec/confidential-guest-support.h
@@ -27,6 +27,10 @@
 #include "igvm/igvm.h"
 #endif
 
+#if defined(CONFIG_IGVM)
+#include "igvm/igvm.h"
+#endif
+
 #define TYPE_CONFIDENTIAL_GUEST_SUPPORT "confidential-guest-support"
 OBJECT_DECLARE_SIMPLE_TYPE(ConfidentialGuestSupport, CONFIDENTIAL_GUEST_SUPPORT)
 
@@ -83,6 +87,7 @@ struct ConfidentialGuestSupport {
      *                Virtual Machine (IGVM) format.
      */
     char *igvm_filename;
+    IgvmHandle igvm;
 #endif
 
     /*

--- a/include/exec/igvm.h
+++ b/include/exec/igvm.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 SUSE
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 or later, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef EXEC_IGVM_H
+#define EXEC_IGVM_H
+
+#include "exec/confidential-guest-support.h"
+
+#if defined(CONFIG_IGVM)
+
+void igvm_file_init(ConfidentialGuestSupport *cgs);
+void igvm_process(ConfidentialGuestSupport *cgs);
+
+#else
+
+static inline void igvm_file_init(ConfidentialGuestSupport *cgs)
+{
+}
+
+static inline void igvm_process(ConfidentialGuestSupport *cgs)
+{
+}
+
+#endif
+
+#endif

--- a/meson.build
+++ b/meson.build
@@ -798,6 +798,11 @@ if targetos == 'linux' and (have_system or have_tools)
                        required: get_option('libudev'),
                        kwargs: static_kwargs)
 endif
+igvm = not_found
+if not get_option('igvm').auto() or have_system
+  igvm = dependency('igvm', required: get_option('igvm'),
+                    method: 'pkg-config', kwargs: static_kwargs)
+endif
 
 mpathlibs = [libudev]
 mpathpersist = not_found
@@ -1934,6 +1939,7 @@ config_host_data.set('CONFIG_CFI', get_option('cfi'))
 config_host_data.set('CONFIG_SELINUX', selinux.found())
 config_host_data.set('CONFIG_XEN_BACKEND', xen.found())
 config_host_data.set('CONFIG_LIBDW', libdw.found())
+config_host_data.set('CONFIG_IGVM', igvm.found())
 if xen.found()
   # protect from xen.version() having less than three components
   xen_version = xen.version().split('.') + ['0', '0']
@@ -4018,6 +4024,7 @@ endif
 summary_info += {'seccomp support':   seccomp}
 summary_info += {'GlusterFS support': glusterfs}
 summary_info += {'TPM support':       have_tpm}
+summary_info += {'IGVM support':      igvm}
 summary_info += {'libssh support':    libssh}
 summary_info += {'lzo support':       lzo}
 summary_info += {'snappy support':    snappy}

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -94,6 +94,8 @@ option('dbus_display', type: 'feature', value: 'auto',
        description: '-display dbus support')
 option('tpm', type : 'feature', value : 'auto',
        description: 'TPM support')
+option('igvm', type: 'feature', value: 'auto',
+       description: 'Independent Guest Virtual Machine (IGVM) file support')
 
 # Do not enable it by default even for Mingw32, because it doesn't
 # work on Wine.

--- a/pc-bios/keymaps/meson.build
+++ b/pc-bios/keymaps/meson.build
@@ -1,5 +1,5 @@
 keymaps = {
-  'ar': '-l ar',
+  'ar': '-l ara',
   'bepo': '-l fr -v dvorak',
   'cz': '-l cz',
   'da': '-l dk',

--- a/qapi/qom.json
+++ b/qapi/qom.json
@@ -831,6 +831,18 @@
   'data': { '*filename': 'str' } }
 
 ##
+# @ConfidentialGuestProperties:
+#
+# Properties common to objects that are derivatives of confidential-guest-support.
+#
+# @igvm-file: IGVM file to use to configure guest (default: none)
+#
+# Since: 8.2
+##
+{ 'struct': 'ConfidentialGuestProperties',
+  'data': { '*igvm-file': 'str' } }
+
+##
 # @SevCommonProperties:
 #
 # Properties common to objects that are derivatives of sev-common.
@@ -853,6 +865,7 @@
 # Since: 2.12
 ##
 { 'struct': 'SevCommonProperties',
+  'base': 'ConfidentialGuestProperties',
   'data': { '*sev-device': 'str',
             '*cbitpos': 'uint32',
             'reduced-phys-bits': 'uint32',

--- a/qemu-options.hx
+++ b/qemu-options.hx
@@ -5390,7 +5390,7 @@ SRST
                  -object secret,id=sec0,keyid=secmaster0,format=base64,\\
                      data=$SECRET,iv=$(<iv.b64)
 
-    ``-object sev-guest,id=id,cbitpos=cbitpos,reduced-phys-bits=val,[sev-device=string,policy=policy,handle=handle,dh-cert-file=file,session-file=file,kernel-hashes=on|off]``
+    ``-object sev-guest,id=id,cbitpos=cbitpos,reduced-phys-bits=val,[sev-device=string,policy=policy,handle=handle,dh-cert-file=file,session-file=file,kernel-hashes=on|off,igvm-file=file]``
         Create a Secure Encrypted Virtualization (SEV) guest object,
         which can be used to provide the guest memory encryption support
         on AMD processors.
@@ -5433,6 +5433,11 @@ SRST
         The ``kernel-hashes`` adds the hashes of given kernel/initrd/
         cmdline to a designated guest firmware page for measured Linux
         boot with -kernel. The default is off. (Since 6.2)
+
+        The ``igvm-file`` allows an Independent Guest Virtual Machine
+        (IGVM) file to be specified that configures the secure virtual
+        machine and can include, for example, an SVSM module, system
+        firmware, initial boot state, etc.
 
         e.g to launch a SEV guest
 
@@ -5597,7 +5602,6 @@ SRST
 
             (qemu) qom-set /objects/iothread1 poll-max-ns 100000
 ERST
-
 
 HXCOMM This is the last statement. Insert new options before this line!
 

--- a/scripts/meson-buildoptions.sh
+++ b/scripts/meson-buildoptions.sh
@@ -105,6 +105,7 @@ meson_options_help() {
   printf "%s\n" '  hax             HAX acceleration support'
   printf "%s\n" '  hvf             HVF acceleration support'
   printf "%s\n" '  iconv           Font glyph conversion support'
+  printf "%s\n" '  igvm            Independent Guest Virtual Machine (IGVM) file support'
   printf "%s\n" '  jack            JACK sound support'
   printf "%s\n" '  keyring         Linux keyring support'
   printf "%s\n" '  kvm             KVM acceleration support'
@@ -298,6 +299,8 @@ _meson_option_parse() {
     --iasl=*) quote_sh "-Diasl=$2" ;;
     --enable-iconv) printf "%s" -Diconv=enabled ;;
     --disable-iconv) printf "%s" -Diconv=disabled ;;
+    --enable-igvm) printf "%s" -Digvm=enabled ;;
+    --disable-igvm) printf "%s" -Digvm=disabled ;;
     --includedir=*) quote_sh "-Dincludedir=$2" ;;
     --enable-install-blobs) printf "%s" -Dinstall_blobs=true ;;
     --disable-install-blobs) printf "%s" -Dinstall_blobs=false ;;

--- a/target/i386/sev.c
+++ b/target/i386/sev.c
@@ -37,6 +37,7 @@
 #include "qapi/qapi-commands-misc-target.h"
 #include "exec/confidential-guest-support.h"
 #include "hw/i386/pc.h"
+#include "hw/i386/e820_memory_layout.h"
 #include "exec/address-spaces.h"
 #include "qemu/queue.h"
 #include "exec/ramblock.h"
@@ -449,6 +450,45 @@ sev_common_class_init(ObjectClass *oc, void *data)
                                   sev_common_set_discard);
 }
 
+static int snp_launch_update_cpuid(uint32_t cpuid_addr, void *hva,
+                                   uint32_t cpuid_len);
+
+static int snp_launch_update_data(uint64_t gpa, void *hva, uint32_t len,
+                                  int type);
+
+static int sev_launch_update_data(SevGuestState *sev_guest, uint8_t *addr,
+                                  uint64_t len, hwaddr start);
+
+static int sev_check_support(ConfidentialGuestPlatformType platform,
+                             uint16_t platform_version, uint8_t highest_vtl,
+                             uint64_t shared_gpa_boundary)
+{
+    return ((platform == CGS_SEV_SNP) && sev_snp_enabled()) ? 1 : 0;
+}
+
+static int sev_set_memory_attributes(hwaddr gpa, uint8_t *ptr, uint64_t len,
+                                     int memory_type)
+{
+    SevCommonState *sev_common = SEV_COMMON(MACHINE(qdev_get_machine())->cgs);
+    int ret = 0;
+
+    if (memory_type == KVM_SEV_SNP_PAGE_TYPE_CPUID) {
+        if (sev_snp_enabled()) {
+            ret = snp_launch_update_cpuid(gpa, ptr, len);
+        }
+    } else if (memory_type != KVM_SEV_SNP_PAGE_TYPE_UNMEASURED) {
+        if (sev_snp_enabled()) {
+            ret = snp_launch_update_data(gpa, ptr, len, memory_type);
+        } else {
+            ret = sev_launch_update_data(SEV_GUEST(sev_common), ptr, len, gpa);
+        }
+    } else {
+        /* Unmeasured guest memory is configured as guest encrypted */
+        ret = kvm_convert_memory(gpa, len, true);
+    }
+    return ret;
+}
+
 static int sev_set_cpu_context(uint16_t cpu_index, const void *ctx,
                                uint32_t ctx_len)
 {
@@ -481,10 +521,44 @@ static int sev_set_cpu_context(uint16_t cpu_index, const void *ctx,
     return 0;
 }
 
+static int sev_get_mem_map_count(void)
+{
+    return e820_get_num_entries();
+}
+
+static void sev_get_mem_map_entry(int index,
+                                  ConfidentialGuestMemoryMapEntry *entry)
+{
+    if ((index < 0) || (index >= sev_get_mem_map_count())) {
+        error_report("CGS: Invalid memory map entry requested");
+        exit(EXIT_FAILURE);
+    }
+    entry->gpa = e820_table[index].address;
+    entry->size = e820_table[index].length;
+    switch (e820_table[index].type) {
+    case E820_RAM:
+        entry->type = CGS_MEM_RAM;
+        break;
+    case E820_RESERVED:
+        entry->type = CGS_MEM_RESERVED;
+        break;
+    case E820_ACPI:
+        entry->type = CGS_MEM_ACPI;
+        break;
+    case E820_NVS:
+        entry->type = CGS_MEM_NVS;
+        break;
+    case E820_UNUSABLE:
+        entry->type = CGS_MEM_UNUSABLE;
+        break;
+    }
+}
+
 static void
 sev_common_instance_init(Object *obj)
 {
     SevCommonState *sev_common = SEV_COMMON(obj);
+    ConfidentialGuestSupport* cgs = CONFIDENTIAL_GUEST_SUPPORT(obj);
 
     sev_common->sev_device = g_strdup(DEFAULT_SEV_DEVICE);
 
@@ -493,6 +567,14 @@ sev_common_instance_init(Object *obj)
     object_property_add_uint32_ptr(obj, "reduced-phys-bits",
                                    &sev_common->reduced_phys_bits,
                                    OBJ_PROP_FLAG_READWRITE);
+
+    cgs->check_support = sev_check_support;
+    cgs->set_memory_attributes = sev_set_memory_attributes;
+    cgs->set_cpu_context = sev_set_cpu_context;
+    cgs->get_mem_map_count = sev_get_mem_map_count;
+    cgs->get_mem_map_entry = sev_get_mem_map_entry;
+
+    QTAILQ_INIT(&sev_common->launch_vmsa);
 }
 
 /* sev guest info common to sev/sev-es/sev-snp */
@@ -1662,21 +1744,29 @@ sev_snp_launch_finish(SevSnpGuestState *sev_snp)
     OvmfSevMetadata *metadata;
     SevLaunchUpdateData *data;
     struct kvm_sev_snp_launch_finish *finish = &sev_snp->kvm_finish_conf;
+    ConfidentialGuestSupport *cgs = CONFIDENTIAL_GUEST_SUPPORT(sev_snp);
 
-    /*
-     * To boot the SNP guest, the hypervisor is required to populate the CPUID
-     * and Secrets page before finalizing the launch flow. The location of
-     * the secrets and CPUID page is available through the OVMF metadata GUID.
+    /* 
+     * Populate all the metadata pages if not using an IGVM file. In the case
+     * where an IGVM file is provided it will be used to configure the metadata
+     * pages directly. 
      */
-    metadata = pc_system_get_ovmf_sev_metadata_ptr();
-    if (metadata == NULL) {
-        error_report("%s: Failed to locate SEV metadata header\n", __func__);
-        exit(1);
+    if (cgs->igvm <= 0) {
+        /*
+        * To boot the SNP guest, the hypervisor is required to populate the CPUID
+        * and Secrets page before finalizing the launch flow. The location of
+        * the secrets and CPUID page is available through the OVMF metadata GUID.
+        */
+        metadata = pc_system_get_ovmf_sev_metadata_ptr();
+        if (metadata == NULL) {
+            error_report("%s: Failed to locate SEV metadata header\n", __func__);
+            exit(1);
+        }
+        
+        /* Populate all the metadata pages */
+        snp_populate_metadata_pages(sev_snp, metadata);
     }
 
-    /* Populate all the metadata pages */
-    snp_populate_metadata_pages(sev_snp, metadata);
-    
     QTAILQ_FOREACH(data, &launch_update, next) {
         ret = sev_snp_launch_update(sev_snp, data);
         if (ret) {

--- a/util/async.c
+++ b/util/async.c
@@ -164,7 +164,21 @@ int aio_bh_poll(AioContext *ctx)
 
     /* Synchronizes with QSLIST_INSERT_HEAD_ATOMIC in aio_bh_enqueue().  */
     QSLIST_MOVE_ATOMIC(&slice.bh_list, &ctx->bh_list);
+
+    /*
+     * GCC13 [-Werror=dangling-pointer=] complains that the local variable
+     * 'slice' is being stored in the global 'ctx->bh_slice_list' but the
+     * list is emptied before this function returns.
+     */
+#if !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wdangling-pointer="
+#endif
     QSIMPLEQ_INSERT_TAIL(&ctx->bh_slice_list, &slice, next);
+#if !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
     while ((s = QSIMPLEQ_FIRST(&ctx->bh_slice_list))) {
         QEMUBH *bh;


### PR DESCRIPTION
This PR adds support for configuration a secure virtual machine guest using files in the Independent Guest Virtual Machine (IGVM) format. IGVM is used to describe the information required to configure and launch guest virtual machines that use isolation technologies such as AMD SEV-SNP. 

See https://crates.io/crates/igvm/0.1.1 for more details on the IGVM format.

For Coconut SVSM, IGVM is set to replace the current method for configuring a guest that includes an SVSM. Therefore this version of QEMU will replace the current svsm-v8.0.0 branch and removes the previous SVSM patches that allow the SVSM to be specified as a flash drive. 

## Dependencies
Support for IGVM within QEMU depends on the IGVM library being installed on the development system. This is currently only available on my own branch at https://github.com/roy-hopkins/igvm/tree/igvm_c. There is a PR open for this: https://github.com/microsoft/igvm/pull/3.

You can build and install the IGVM C library using these commands:

```
git clone https://github.com/roy-hopkins/igvm/tree/igvm_c
cd igvm
make -f igvm_c/Makefile
sudo make -f igvm_c/Makefile install
```

## Building QEMU with support for IGVM
IGVM support within this version of QEMU is optional but is enabled by default if the IGVM library is found on the development system. However, to ensure the build only succeeds if the IGVM library is present you can use the following option on the `configure` command:

```
---enable-igvm
```

## Building Coconut SVSM and OVMF into an IGVM file
The current `main` branch of coconut SVSM supports building an IGVM file that contains both the SVSM and OVMF. However, OVMF is not built into the image by default. To build OVMF into the file, use the following build command: 

```
cd svsm
FW_FILE=/path/to/OVMF.fd make
```

Note that only the file `OVMF.fd` is required, not `OVMF_CODE.fd` and `OVMF_VARS.fd`.

## Running the guest
The command line to start a guest supporting SVSM has change for IGVM. There is no need to specify any flash volumes for OVMF or SVSM as these are now contained in the IGVM file. An example command to run QEMU is:

```
        $IGVM=/path/to/coconut-svsm/bin/coconut-qemu.igvm
	$qemu-system-x86_64 \
         -enable-kvm \
	     -cpu EPYC-v4 \
	     -machine q35,confidential-guest-support=sev0,memory-backend=mem0,kvm-type=protected \
	     -object memory-backend-memfd-private,size=8G,id=mem0,share=true \
	     -object sev-snp-guest,id=sev0,cbitpos=51,reduced-phys-bits=1,igvm-file=$IGVM \
             -smp 4 \
             -no-reboot \
	     -display curses \
	     -nographic \
             -netdev user,id=vmnic -device e1000,netdev=vmnic,romfile= \
             -drive file=$IMAGE,if=none,id=disk0,format=qcow2,snapshot=on \
             -device virtio-scsi-pci,id=scsi0,disable-legacy=on,iommu_platform=on \
             -device scsi-hd,drive=disk0,bootindex=0 \
             -monitor tcp:0.0.0.0:1235,server,nowait \
	     -vga none \
             -serial stdio \
	     -serial pty \
             -vnc :2 
```
