### PR TITLE
sev: Change page type from zero to normal for zero pages

### DIFF
--- a/target/i386/sev.c
+++ b/target/i386/sev.c
@@ -554,8 +554,7 @@ static int cgs_set_guest_state(hwaddr gpa, uint8_t *ptr, uint64_t len,
         case CGS_PAGE_TYPE_ZERO:
             if (sev_snp_enabled()) {
                 ret = snp_launch_update_data(gpa, ptr, len,
-                (memory_type == CGS_PAGE_TYPE_NORMAL) ?
-                    KVM_SEV_SNP_PAGE_TYPE_NORMAL : KVM_SEV_SNP_PAGE_TYPE_ZERO);
+                                             KVM_SEV_SNP_PAGE_TYPE_NORMAL);
             }
             else {
                 ret = sev_launch_update_data(SEV_GUEST(MACHINE(qdev_get_machine())->cgs),


### PR DESCRIPTION
Guest pages consisting of only zeroes can be measured in two different ways for SEV-SNP when calling snp_launch_update_data(): either using the SNP native KVM_SEV_SNP_PAGE_TYPE_ZERO or as KVM_SEV_SNP_PAGE_TYPE_NORMAL as long as the page of zeros has already been populated in the guest.

The IGVM specification v0.1.6 mandates the use of the zero page type in this case but other production IGVM loaders incorrectly use the normal page type. The specification is going to be changed to match the other loaders so this commit changes the QEMU behavior to match the other loaders.

Without this, IGVM measurement and signing tools would need to behave differently depending on which hypervisor they are targetting.