### PR TITLE
Implement IGVM policy and ID block support

### DIFF
--- a/backends/confidential-guest-support.c
+++ b/backends/confidential-guest-support.c
@@ -68,6 +68,17 @@ static int set_guest_state(hwaddr gpa, uint8_t *ptr, uint64_t len,
     return -1;
 }
 
+static int set_guest_policy(ConfidentialGuestPolicyType policy_type,
+                            uint64_t policy,
+                            void *policy_data1, uint32_t policy_data1_size,
+                            void *policy_data2, uint32_t policy_data2_size,
+                            Error **errp)
+{
+    error_setg(errp,
+               "Setting confidential guest policy is not supported for this platform");
+    return -1;
+}
+
 static int get_mem_map_entry(int index, ConfidentialGuestMemoryMapEntry *entry,
                              Error **errp)
 {
@@ -82,6 +93,7 @@ static void confidential_guest_support_init(Object *obj)
     ConfidentialGuestSupport *cgs = CONFIDENTIAL_GUEST_SUPPORT(obj);
     cgs->check_support = check_support;
     cgs->set_guest_state = set_guest_state;
+    cgs->set_guest_policy = set_guest_policy;
     cgs->get_mem_map_entry = get_mem_map_entry;
 }
 

--- a/backends/igvm.c
+++ b/backends/igvm.c
@@ -101,17 +101,20 @@ static int directive_vp_context(struct igvm_context *ctx, int i,
 static int directive_parameter_area(struct igvm_context *ctx, int i,
                                const uint8_t *header_data, Error **errp);
 static int directive_parameter_insert(struct igvm_context *ctx, int i,
-                                const uint8_t *header_data, Error **errp);
+                               const uint8_t *header_data, Error **errp);
 static int directive_memory_map(struct igvm_context *ctx, int i,
-                                    const uint8_t *header_data, Error **errp);
+                               const uint8_t *header_data, Error **errp);
 static int directive_vp_count(struct igvm_context *ctx, int i,
-                                      const uint8_t *header_data, Error **errp);
+                               const uint8_t *header_data, Error **errp);
 static int directive_environment_info(struct igvm_context *ctx, int i,
-                                const uint8_t *header_data, Error **errp);
+                               const uint8_t *header_data, Error **errp);
 static int directive_required_memory(struct igvm_context *ctx, int i,
-                              const uint8_t *header_data, Error **errp);
+                               const uint8_t *header_data, Error **errp);
 static int directive_snp_id_block(struct igvm_context *ctx, int i,
-                                      const uint8_t *header_data, Error **errp);
+                               const uint8_t *header_data, Error **errp);
+
+static int initialization_guest_policy(struct igvm_context *ctx, int i,
+                               const uint8_t *header_data, Error **errp);
 
 struct IGVMHandler {
     uint32_t type;
@@ -130,7 +133,7 @@ static struct IGVMHandler handlers[] = {
     { IGVM_VHT_ENVIRONMENT_INFO_PARAMETER, HEADER_SECTION_DIRECTIVE, directive_environment_info },
     { IGVM_VHT_REQUIRED_MEMORY, HEADER_SECTION_DIRECTIVE, directive_required_memory },
     { IGVM_VHT_SNP_ID_BLOCK, HEADER_SECTION_DIRECTIVE, directive_snp_id_block },
-
+    { IGVM_VHT_GUEST_POLICY, HEADER_SECTION_INITIALIZATION, initialization_guest_policy },
 };
 
 static int handle(uint32_t type, struct igvm_context *ctx, int i, Error **errp)
@@ -682,6 +685,18 @@ static int directive_snp_id_block(struct igvm_context *ctx, int i,
                72);
     }
 
+    return 0;
+}
+
+static int initialization_guest_policy(struct igvm_context *ctx, int i,
+                                     const uint8_t *header_data, Error **errp)
+{
+    const IGVM_VHS_GUEST_POLICY *guest =
+        (const IGVM_VHS_GUEST_POLICY *)header_data;
+
+    if (guest->compatibility_mask & ctx->compatibility_mask) {
+        ctx->sev_policy = guest->policy;
+    }
     return 0;
 }
 

--- a/include/exec/confidential-guest-support.h
+++ b/include/exec/confidential-guest-support.h
@@ -64,6 +64,10 @@ typedef enum ConfidentialGuestPageType {
     CGS_PAGE_TYPE_REQUIRED_MEMORY,
 } ConfidentialGuestPageType;
 
+typedef enum ConfidentialGuestPolicyType {
+    GUEST_POLICY_SEV,
+} ConfidentialGuestPolicyType;
+
 struct ConfidentialGuestSupport {
     Object parent;
 
@@ -131,6 +135,23 @@ struct ConfidentialGuestSupport {
     int (*set_guest_state)(hwaddr gpa, uint8_t *ptr, uint64_t len,
                            ConfidentialGuestPageType memory_type,
                            uint16_t cpu_index, Error **errp);
+
+    /*
+     * Set the guest policy. The policy can be used to configure the
+     * confidential platform, such as if debug is enabled or not and can contain
+     * information about expected launch measurements, signed verification of
+     * guest configuration and other platform data.
+     *
+     * The format of the policy data is specific to each platform. For example,
+     * SEV-SNP uses a policy bitfield in the 'policy' argument and provides an
+     * ID block and ID authentication in the 'policy_data' parameters. The type
+     * of policy data is identified by the 'policy_type' argument.
+     */
+    int (*set_guest_policy)(ConfidentialGuestPolicyType policy_type,
+                            uint64_t policy,
+                            void *policy_data1, uint32_t policy_data1_size,
+                            void *policy_data2, uint32_t policy_data2_size,
+                            Error **errp);
 
     /*
      * Iterate the system memory map, getting the entry with the given index

--- a/target/i386/sev.c
+++ b/target/i386/sev.c
@@ -433,7 +433,7 @@ static void sev_apply_cpu_context(CPUState *cpu)
                 launch_vmsa->vmsa.ss.base, launch_vmsa->vmsa.ss.limit,
                 FLAGS_VMSA_TO_SEGCACHE(launch_vmsa->vmsa.ss.attrib));
 
-            env->dr[6] = launch_vmsa->vmsa.dr6;
+                        env->dr[6] = launch_vmsa->vmsa.dr6;
             env->dr[7] = launch_vmsa->vmsa.dr7;
 
             env->regs[R_EAX] = launch_vmsa->vmsa.rax;
@@ -482,7 +482,7 @@ static int check_vmsa_supported(const struct sev_es_save_area *vmsa)
     memset(&vmsa_check.ds, 0, sizeof(vmsa_check.ds));
     memset(&vmsa_check.fs, 0, sizeof(vmsa_check.fs));
     memset(&vmsa_check.gs, 0, sizeof(vmsa_check.gs));
-    vmsa_check.efer = 0;
+        vmsa_check.efer = 0;
     vmsa_check.cr0 = 0;
     vmsa_check.cr3 = 0;
     vmsa_check.cr4 = 0;
@@ -667,6 +667,83 @@ out:
     return ret;
 }
 
+static int cgs_set_guest_policy(ConfidentialGuestPolicyType policy_type,
+                            uint64_t policy,
+                            void *policy_data1, uint32_t policy_data1_size,
+                            void *policy_data2, uint32_t policy_data2_size,
+                            Error **errp)
+{
+    if (policy_type != GUEST_POLICY_SEV) {
+        error_setg(errp, "%s: Invalid guest policy type provided for SEV: %d",
+        __func__, policy_type);
+        return -1;
+    }
+    /*
+     * SEV-SNP handles policy differently. The policy flags are defined in
+     * kvm_start_conf.policy and an ID block and ID auth can be provided.
+     */
+    if (sev_snp_enabled()) {
+        SevSnpGuestState *sev_snp_guest = SEV_SNP_GUEST(MACHINE(qdev_get_machine())->cgs);
+        struct kvm_sev_snp_launch_finish *finish = &sev_snp_guest->kvm_finish_conf;
+
+        /*
+        * The policy consists of flags in 'policy' and optionally an ID block and
+        * ID auth in policy_data1 and policy_data2 respectively.
+        * The ID block and auth are optional so clear any previous ID block and
+        * auth and set them if provided, but always set the policy flags.
+        */
+        g_free(sev_snp_guest->id_block);
+        g_free((guchar *)finish->id_block_uaddr);
+        g_free(sev_snp_guest->id_auth);
+        g_free((guchar *)finish->id_auth_uaddr);
+        sev_snp_guest->id_block = NULL;
+        finish->id_block_uaddr = 0;
+        sev_snp_guest->id_auth = NULL;
+        finish->id_auth_uaddr = 0;
+
+        if (policy_data1_size > 0) {
+            struct sev_snp_id_authentication *id_auth = (struct sev_snp_id_authentication *)policy_data2;
+
+            if (policy_data1_size != KVM_SEV_SNP_ID_BLOCK_SIZE) {
+                error_setg(errp, "%s: Invalid SEV-SNP ID block: incorrect size",
+                        __func__);
+                return -1;
+            }
+            if (policy_data2_size != KVM_SEV_SNP_ID_AUTH_SIZE) {
+                error_setg(errp, "%s: Invalid SEV-SNP ID auth block: incorrect size",
+                        __func__);
+                return -1;
+            }
+            finish->id_block_uaddr = (__u64)g_malloc0(KVM_SEV_SNP_ID_BLOCK_SIZE);
+            finish->id_auth_uaddr = (__u64)g_malloc0(KVM_SEV_SNP_ID_AUTH_SIZE);
+            memcpy((void *)finish->id_block_uaddr, policy_data1, KVM_SEV_SNP_ID_BLOCK_SIZE);
+            memcpy((void *)finish->id_auth_uaddr, policy_data2, KVM_SEV_SNP_ID_AUTH_SIZE);
+
+            /*
+             * Check if an author key has been provided and use that to flag
+             * whether the author key is enabled. The first of the author key
+             * must be non-zero to indicate the key type, which will currently
+             * always be 2.
+             */
+            sev_snp_guest->kvm_finish_conf.auth_key_en =
+                    id_auth->author_key[0] ? 1 : 0;
+            finish->id_block_en = 1;
+        }
+        sev_snp_guest->kvm_start_conf.policy = policy;
+    }
+    else {
+        SevGuestState *sev_guest = SEV_GUEST(MACHINE(qdev_get_machine())->cgs);
+        /* Only the policy flags are supported for SEV and SEV-ES */
+        if ((policy_data1_size > 0) || (policy_data2_size > 0) || !sev_guest) {
+            error_setg(errp, "%s: An ID block/ID auth block has been provided "
+                             "but SEV-SNP is not supported", __func__);
+            return -1;
+        }
+        sev_guest->policy = policy;
+    }
+    return 0;
+}
+
 static int cgs_get_mem_map_entry(int index,
                                  ConfidentialGuestMemoryMapEntry *entry,
                                  Error **errp)
@@ -749,6 +826,7 @@ sev_common_instance_init(Object *obj)
 
     cgs->check_support = cgs_check_support;
     cgs->set_guest_state = cgs_set_guest_state;
+    cgs->set_guest_policy = cgs_set_guest_policy;
     cgs->get_mem_map_entry = cgs_get_mem_map_entry;
 
     QTAILQ_INIT(&sev_common->launch_vmsa);

--- a/target/i386/sev.c
+++ b/target/i386/sev.c
@@ -2066,7 +2066,7 @@ sev_snp_launch_finish(SevSnpGuestState *sev_snp)
                                     sev_snp->host_data);
     ret = sev_ioctl(SEV_COMMON(sev_snp)->sev_fd, KVM_SEV_SNP_LAUNCH_FINISH,
                     finish, &error);
-    if (ret) {
+    if (ret || error) {
         error_report("%s: SNP_LAUNCH_FINISH ret=%d fw_error=%d '%s'",
                      __func__, ret, error, fw_error_to_str(error));
         exit(1);

--- a/target/i386/sev.h
+++ b/target/i386/sev.h
@@ -155,6 +155,18 @@ struct QEMU_PACKED sev_es_save_area {
 	uint8_t fpreg_ymm[256];
 };
 
+struct QEMU_PACKED sev_snp_id_authentication {
+	uint32_t id_key_alg;
+	uint32_t auth_key_algo;
+	uint8_t reserved[56];
+	uint8_t id_block_sig[512];
+	uint8_t id_key[1028];
+	uint8_t reserved2[60];
+	uint8_t id_key_sig[512];
+	uint8_t author_key[1028];
+	uint8_t reserved3[892];
+};
+
 #ifdef CONFIG_SEV
 bool sev_enabled(void);
 bool sev_es_enabled(void);


### PR DESCRIPTION
This PR extends the IGVM loader functionality to handle SEV policy and SEV-SNP ID blocks.

Previously, both SEV policy and SEV-SNP ID blocks could be configured via object parameters (e.g. on the command line). However, this information can be provided inside an IGVM file which should then be used to configure the policy and ID block configuration.

New handlers have been added to the IGVM loader to determine the SEV policy and ID block information if present. This is then passed to a new `ConfidentialGuestSupport` handler: `cgs_set_guest_policy()` which then populates the same structures used by the command-line configuration.

This results in the ability to define a guest policy in the IGVM builder, then to sign the IGVM file using an ID key and optionally an author key. If this signed file is then provided to the QEMU IGVM loader, the policy is applied and the ID block and ID auth blocks are built and used to validate the guest configuration at startup.

A signed IGVM file can be generated that works with this QEMU by using the coconut-SVSM branch in this PR: https://github.com/coconut-svsm/svsm/pull/315