### PR TITLE
Fix compile error when built without --enable-igvm

### DIFF
--- a/include/exec/igvm.h
+++ b/include/exec/igvm.h
@@ -29,6 +29,7 @@ static inline int igvm_file_init(ConfidentialGuestSupport *cgs, Error **errp)
 
 static inline int igvm_process(ConfidentialGuestSupport *cgs, Error **errp)
 {
+    return 0;
 }
 
 #endif


### PR DESCRIPTION
Fix compile error due to no return statement in function returning non-void.

Steps to repro:
```
$ git clone https://github.com/coconut-svsm/qemu
$ cd qemu
$ git checkout svsm-igvm

$ mkdir build && cd build
$ ../configure --enable-kvm --target-list=x86_64-softmmu --enable-debug
$ make