### PR TITLE
Add support for TD-Partitioning

### DIFF
--- a/hw/i386/acpi-build.c
+++ b/hw/i386/acpi-build.c
@@ -2771,11 +2771,10 @@ static void acpi_build_update(void *build_opaque)
     AcpiBuildState *build_state = build_opaque;
     AcpiBuildTables tables;
 
-    /* No state to update or already patched? Nothing to do. */
-    if (!build_state || build_state->patched) {
+    /* No state? Nothing to do. */
+    if (!build_state) {
         return;
     }
-    build_state->patched = 1;
 
     acpi_build_tables_init(&tables);
 
@@ -2791,12 +2790,6 @@ static void acpi_build_update(void *build_opaque)
 
     acpi_ram_update(build_state->linker_mr, tables.linker->cmd_blob);
     acpi_build_tables_cleanup(&tables, true);
-}
-
-static void acpi_build_reset(void *build_opaque)
-{
-    AcpiBuildState *build_state = build_opaque;
-    build_state->patched = 0;
 }
 
 static const VMStateDescription vmstate_acpi_build = {
@@ -2894,8 +2887,6 @@ void acpi_setup(void)
                                                  ACPI_BUILD_RSDP_FILE);
     }
 
-    qemu_register_reset(acpi_build_reset, build_state);
-    acpi_build_reset(build_state);
     vmstate_register(NULL, 0, &vmstate_acpi_build, build_state);
 
     /* Cleanup tables but don't free the memory: we track it

--- a/hw/i386/microvm.c
+++ b/hw/i386/microvm.c
@@ -278,7 +278,7 @@ static void microvm_devices_init(MicrovmMachineState *mms)
     default_firmware = x86_machine_is_acpi_enabled(x86ms)
             ? MICROVM_BIOS_FILENAME
             : MICROVM_QBOOT_FILENAME;
-    x86_bios_rom_init(MACHINE(mms), default_firmware, get_system_memory(), true);
+    x86_bios_rom_init(MACHINE(mms), default_firmware, NULL, get_system_memory(), true);
 }
 
 static void microvm_memory_init(MicrovmMachineState *mms)

--- a/hw/i386/pc.c
+++ b/hw/i386/pc.c
@@ -1084,6 +1084,8 @@ void pc_memory_init(PCMachineState *pcms,
 
     /* Init ACPI memory hotplug IO base address */
     pcms->memhp_io_base = ACPI_MEMORY_HOTPLUG_BASE;
+
+    tdx_init_fw_cfg(machine);
 }
 
 /*

--- a/hw/i386/pc.c
+++ b/hw/i386/pc.c
@@ -1722,6 +1722,20 @@ static void pc_machine_set_max_fw_size(Object *obj, Visitor *v,
     pcms->max_fw_size = value;
 }
 
+static char *pc_machine_get_firmware(Object *obj, Error **errp)
+{
+    PCMachineState *pcms = PC_MACHINE(obj);
+
+    return g_strdup(pcms->firmware2);
+}
+
+static void pc_machine_set_firmware(Object *obj, const char *value, Error **errp)
+{
+    PCMachineState *pcms = PC_MACHINE(obj);
+
+    g_free(pcms->firmware2);
+    pcms->firmware2 = g_strdup(value);
+}
 
 static void pc_machine_initfn(Object *obj)
 {
@@ -1891,6 +1905,11 @@ static void pc_machine_class_init(ObjectClass *oc, void *data)
         NULL, NULL);
     object_class_property_set_description(oc, PC_MACHINE_SMBIOS_EP,
         "SMBIOS Entry Point type [32, 64]");
+
+    object_class_property_add_str(oc, "l2bios",
+        pc_machine_get_firmware, pc_machine_set_firmware);
+    object_class_property_set_description(oc, "l2bios",
+        "Firmware image for L2");
 }
 
 static const TypeInfo pc_machine_info = {

--- a/hw/i386/pc.c
+++ b/hw/i386/pc.c
@@ -903,10 +903,12 @@ void pc_memory_init(PCMachineState *pcms,
     hwaddr cxl_base, cxl_resv_end = 0;
     X86CPU *cpu = X86_CPU(first_cpu);
 
+    linux_boot = (machine->kernel_filename != NULL);
+
+    tdx_mem_init(machine);
+
     assert(machine->ram_size == x86ms->below_4g_mem_size +
                                 x86ms->above_4g_mem_size);
-
-    linux_boot = (machine->kernel_filename != NULL);
 
     /*
      * The HyperTransport range close to the 1T boundary is unique to AMD

--- a/hw/i386/pc_sysfw.c
+++ b/hw/i386/pc_sysfw.c
@@ -211,7 +211,7 @@ void pc_system_firmware_init(PCMachineState *pcms,
     BlockBackend *pflash_blk[ARRAY_SIZE(pcms->flash)];
 
     if (!pcmc->pci_enabled) {
-        x86_bios_rom_init(MACHINE(pcms), "bios.bin", rom_memory, true);
+        x86_bios_rom_init(MACHINE(pcms), "bios.bin", pcms->firmware2, rom_memory, true);
         return;
     }
 
@@ -236,7 +236,7 @@ void pc_system_firmware_init(PCMachineState *pcms,
          * in which case the firmware must be provided by the IGVM file.
          */
         if (!cgs_is_igvm(MACHINE(pcms)->cgs)) {
-            x86_bios_rom_init(MACHINE(pcms), "bios.bin", rom_memory, false);
+            x86_bios_rom_init(MACHINE(pcms), "bios.bin", pcms->firmware2, rom_memory, false);
         }
     } else {
         if (kvm_enabled() && !kvm_readonly_mem_enabled()) {

--- a/hw/i386/tdvf-hob.c
+++ b/hw/i386/tdvf-hob.c
@@ -106,17 +106,19 @@ static void tdvf_hob_add_memory_resources(TdxGuest *tdx, TdvfHob *hob)
 
 void tdvf_hob_create(TdxGuest *tdx, TdxFirmwareEntry *td_hob)
 {
-    TdvfHob hob = {
-        .hob_addr = td_hob->address,
-        .size = td_hob->size,
-        .ptr = td_hob->mem_ptr,
-
-        .current = td_hob->mem_ptr,
-        .end = td_hob->mem_ptr + td_hob->size,
-    };
-
+    TdvfHob hob;
     EFI_HOB_GENERIC_HEADER *last_hob;
     EFI_HOB_HANDOFF_INFO_TABLE *hit;
+
+    if (!td_hob) {
+        return;
+    }
+
+    hob.hob_addr = td_hob->address,
+    hob.size = td_hob->size,
+    hob.ptr = td_hob->mem_ptr,
+    hob.current = td_hob->mem_ptr,
+    hob.end = td_hob->mem_ptr + td_hob->size,
 
     /* Note, Efi{Free}Memory{Bottom,Top} are ignored, leave 'em zeroed. */
     hit = tdvf_get_area(&hob, sizeof(*hit));

--- a/hw/i386/x86.c
+++ b/hw/i386/x86.c
@@ -1135,12 +1135,13 @@ void x86_load_linux(X86MachineState *x86ms,
 }
 
 void x86_bios_rom_init(MachineState *ms, const char *default_firmware,
-                       MemoryRegion *rom_memory, bool isapc_ram_fw)
+                       const char *firmware2, MemoryRegion *rom_memory,
+                       bool isapc_ram_fw)
 {
     const char *bios_name;
-    char *filename;
-    MemoryRegion *bios, *isa_bios;
-    int bios_size, isa_bios_size;
+    char *filename, *filename2 = NULL;
+    MemoryRegion *bios, *bios2 = NULL, *isa_bios;
+    int bios_size, bios2_size = 0, isa_bios_size;
     ssize_t ret;
 
     /* BIOS load */
@@ -1176,6 +1177,27 @@ void x86_bios_rom_init(MachineState *ms, const char *default_firmware,
         void *ptr = memory_region_get_ram_ptr(bios);
         load_image_size(filename, ptr, bios_size);
         x86_firmware_configure(0x100000000ULL - bios_size, ptr, bios_size);
+
+        if (firmware2) {
+            /* BIOS2 load */
+            bios_name = firmware2;
+            filename2 = qemu_find_file(QEMU_FILE_TYPE_BIOS, bios_name);
+            if (filename2) {
+                bios2_size = get_image_size(filename2);
+            } else {
+                bios2_size = -1;
+            }
+            if (bios2_size <= 0 ||
+                    (bios2_size % 65536) != 0) {
+                goto bios_error;
+            }
+            bios2 = g_malloc(sizeof(*bios2));
+            memory_region_init_ram_guest_memfd(bios2, NULL, "pc.bios2", bios2_size, &error_fatal);
+            tdx_set_bios2_region(bios2);
+
+            ptr = memory_region_get_ram_ptr(bios2);
+            load_image_size(filename2, ptr, bios2_size);
+        }
     } else {
         if (!isapc_ram_fw) {
             memory_region_set_readonly(bios, true);
@@ -1186,6 +1208,7 @@ void x86_bios_rom_init(MachineState *ms, const char *default_firmware,
         }
     }
     g_free(filename);
+    g_free(filename2);
 
     /* For TDX, alias different GPAs to same private memory is not supported */
     if (!is_tdx_vm()) {
@@ -1203,9 +1226,15 @@ void x86_bios_rom_init(MachineState *ms, const char *default_firmware,
         }
     }
 
-    /* map all the bios at the top of memory */
+    if (bios2) {
+        /* map bios2 at the top of memory */
+        memory_region_add_subregion(rom_memory,
+                                    (uint32_t)(-bios2_size),
+                                    bios2);
+    }
+    /* map bios right below bios2, or at the top of memory */
     memory_region_add_subregion(rom_memory,
-                                (uint32_t)(-bios_size),
+                                (uint32_t)(-(bios_size + bios2_size)),
                                 bios);
     return;
 

--- a/include/exec/igvm.h
+++ b/include/exec/igvm.h
@@ -29,6 +29,7 @@ static inline int igvm_file_init(ConfidentialGuestSupport *cgs, Error **errp)
 
 static inline int igvm_process(ConfidentialGuestSupport *cgs, Error **errp)
 {
+    return 0;
 }
 
 #endif

--- a/include/exec/memory.h
+++ b/include/exec/memory.h
@@ -2550,6 +2550,8 @@ void memory_global_dirty_log_sync(bool last_stage);
  */
 void memory_global_after_dirty_log_sync(void);
 
+hwaddr memory_region_to_absolute_addr(MemoryRegion *mr, hwaddr offset);
+
 /**
  * memory_region_transaction_begin: Start a transaction.
  *

--- a/include/hw/i386/pc.h
+++ b/include/hw/i386/pc.h
@@ -44,6 +44,7 @@ typedef struct PCMachineState {
     OnOffAuto vmport;
     SmbiosEntryPointType smbios_entry_point_type;
     const char *south_bridge;
+    char *firmware2;
 
     bool acpi_build_enabled;
     bool smbus_enabled;

--- a/include/hw/i386/tdvf.h
+++ b/include/hw/i386/tdvf.h
@@ -48,6 +48,8 @@ typedef struct TdxFirmware {
 
     uint32_t nr_entries;
     TdxFirmwareEntry *entries;
+
+    bool svsm_found;
 } TdxFirmware;
 
 #define for_each_tdx_fw_entry(fw, e)    \

--- a/include/hw/i386/x86.h
+++ b/include/hw/i386/x86.h
@@ -119,7 +119,8 @@ void x86_cpu_unplug_cb(HotplugHandler *hotplug_dev,
                        DeviceState *dev, Error **errp);
 
 void x86_bios_rom_init(MachineState *ms, const char *default_firmware,
-                       MemoryRegion *rom_memory, bool isapc_ram_fw);
+                       const char *firmware2, MemoryRegion *rom_memory,
+                       bool isapc_ram_fw);
 
 void x86_load_linux(X86MachineState *x86ms,
                     FWCfgState *fw_cfg,

--- a/linux-headers/asm-x86/kvm.h
+++ b/linux-headers/asm-x86/kvm.h
@@ -616,7 +616,8 @@ struct kvm_tdx_capabilities {
 	__u64 xfam_fixed0;
 	__u64 xfam_fixed1;
 	__u32 supported_gpaw;
-	__u32 padding;
+	__u8  max_num_l2_vms;
+	__u8  padding[3];
 	__u64 reserved[251];
 
 	__u32 nr_cpuid_configs;
@@ -628,13 +629,15 @@ struct kvm_tdx_init_vm {
 	__u64 mrconfigid[6];	/* sha384 digest */
 	__u64 mrowner[6];	/* sha384 digest */
 	__u64 mrownerconfig[6];	/* sha384 digest */
+	__u8  num_l2_vms;
+	__u8  padding[7];
 	/*
 	 * For future extensibility to make sizeof(struct kvm_tdx_init_vm) = 8KB.
 	 * This should be enough given sizeof(TD_PARAMS) = 1024.
 	 * 8KB was chosen given because
 	 * sizeof(struct kvm_cpuid_entry2) * KVM_MAX_CPUID_ENTRIES(=256) = 8KB.
 	 */
-	__u64 reserved[1004];
+	__u64 reserved[1003];
 
 	/*
 	 * Call KVM_TDX_INIT_VM before vcpu creation, thus before

--- a/qapi/qom.json
+++ b/qapi/qom.json
@@ -986,6 +986,9 @@
 #     TD guest cannot get TD quoting for attestation if QGS is not
 #     provided.  So admin should always provide it.
 #
+# @num-l2-vms: command-line option to specify number of L2 VMs that
+#     will be supported by the TD guest.
+#
 # Since: 9.0
 ##
 { 'struct': 'TdxGuestProperties',
@@ -993,7 +996,8 @@
             '*mrconfigid': 'str',
             '*mrowner': 'str',
             '*mrownerconfig': 'str',
-            '*quote-generation-socket': 'SocketAddress' } }
+            '*quote-generation-socket': 'SocketAddress',
+            '*num-l2-vms': 'uint8' } }
 
 ##
 # @ThreadContextProperties:

--- a/qapi/qom.json
+++ b/qapi/qom.json
@@ -989,6 +989,12 @@
 # @num-l2-vms: command-line option to specify number of L2 VMs that
 #     will be supported by the TD guest.
 #
+# @svsm: whether SVSM is used as L1 TD
+#
+# @svsmbase: SVSM's starting GPA
+#
+# @svsmsize: size of SVSM
+#
 # Since: 9.0
 ##
 { 'struct': 'TdxGuestProperties',
@@ -997,7 +1003,10 @@
             '*mrowner': 'str',
             '*mrownerconfig': 'str',
             '*quote-generation-socket': 'SocketAddress',
-            '*num-l2-vms': 'uint8' } }
+            '*num-l2-vms': 'uint8',
+            '*svsm': 'bool',
+            '*svsmbase': 'uint64',
+            '*svsmsize': 'uint64' } }
 
 ##
 # @ThreadContextProperties:

--- a/system/memory.c
+++ b/system/memory.c
@@ -411,7 +411,7 @@ static inline uint64_t memory_region_shift_write_access(uint64_t *value,
     return tmp;
 }
 
-static hwaddr memory_region_to_absolute_addr(MemoryRegion *mr, hwaddr offset)
+hwaddr memory_region_to_absolute_addr(MemoryRegion *mr, hwaddr offset)
 {
     MemoryRegion *root;
     hwaddr abs_addr = offset;

--- a/target/i386/kvm/tdx.c
+++ b/target/i386/kvm/tdx.c
@@ -489,8 +489,8 @@ static TdxFirmwareEntry *tdx_get_hob_entry(TdxGuest *tdx)
             return entry;
         }
     }
-    error_report("TDVF metadata doesn't specify TD_HOB location.");
-    exit(1);
+
+    return NULL;
 }
 
 static void tdx_add_ram_entry(uint64_t address, uint64_t length,
@@ -600,12 +600,17 @@ static void tdx_init_ram_entries(void)
 static void tdx_post_init_vcpus(void)
 {
     TdxFirmwareEntry *hob;
+    void *hob_addr = NULL;
     CPUState *cpu;
     int r;
 
     hob = tdx_get_hob_entry(tdx_guest);
+    if (hob) {
+        hob_addr = (void *)hob->address;
+    }
+
     CPU_FOREACH(cpu) {
-        r = tdx_vcpu_ioctl(cpu, KVM_TDX_INIT_VCPU, 0, (void *)hob->address);
+        r = tdx_vcpu_ioctl(cpu, KVM_TDX_INIT_VCPU, 0, hob_addr);
         if (r < 0) {
             error_report("KVM_TDX_INIT_VCPU failed %s", strerror(-r));
             exit(1);

--- a/target/i386/kvm/tdx.c
+++ b/target/i386/kvm/tdx.c
@@ -688,6 +688,13 @@ void tdx_init_fw_cfg(MachineState *ms)
     data.size = cpu_to_le64(tdx->svsm_size);
 
     fw_cfg_add_file(x86ms->fw_cfg, "etc/tdx/svsm", g_memdup(&data, sizeof(data)), sizeof(data));
+
+    if (tdx->bios2_region) {
+        data.base = cpu_to_le64((uint64_t)memory_region_to_absolute_addr(tdx->bios2_region, 0));
+        data.size = cpu_to_le64(memory_region_size(tdx->bios2_region));
+        fw_cfg_add_file(x86ms->fw_cfg, "etc/tdx/l2bios",
+                g_memdup(&data, sizeof(data)), sizeof(data));
+    }
 }
 
 static void tdx_finalize_vm(Notifier *notifier, void *unused)

--- a/target/i386/kvm/tdx.c
+++ b/target/i386/kvm/tdx.c
@@ -741,6 +741,13 @@ static int tdx_kvm_init(ConfidentialGuestSupport *cgs, Error **errp)
         }
     }
 
+    /* Sanity check. The num_l2_vms should not exceed the max_num_l2_vms */
+    if (tdx->num_l2_vms > tdx_caps->max_num_l2_vms) {
+        error_setg(errp, "TDX VM doesn't support %d L2 VMs, maximum %d",
+                   tdx->num_l2_vms, tdx_caps->max_num_l2_vms);
+        return -EINVAL;
+    }
+
     update_tdx_cpuid_lookup_by_tdx_caps();
 
     /*
@@ -875,6 +882,7 @@ int tdx_pre_create_vcpu(CPUState *cpu, Error **errp)
     init_vm->cpuid.nent = kvm_x86_arch_cpuid(env, init_vm->cpuid.entries, 0);
 
     init_vm->attributes = tdx_guest->attributes;
+    init_vm->num_l2_vms = tdx_guest->num_l2_vms;
 
     do {
         r = tdx_vm_ioctl(KVM_TDX_INIT_VM, 0, init_vm);
@@ -1362,6 +1370,9 @@ static void tdx_guest_init(Object *obj)
 
     tdx->event_notify_vector = -1;
     tdx->event_notify_apicid = -1;
+
+    object_property_add_uint8_ptr(obj, "num-l2-vms", &tdx->num_l2_vms,
+                                  OBJ_PROP_FLAG_READWRITE);
 }
 
 static void tdx_guest_finalize(Object *obj)

--- a/target/i386/kvm/tdx.h
+++ b/target/i386/kvm/tdx.h
@@ -64,6 +64,11 @@ typedef struct TdxGuest {
     /* GetQuote */
     TdxQuoteGenerator *quote_generator;
 
+    /* SVSM location in guest physical address space */
+    bool svsm_enabled;
+    uint64_t svsm_base;
+    uint64_t svsm_size;
+
     uint8_t num_l2_vms;
     MemoryRegion *bios2_region;
 } TdxGuest;
@@ -74,6 +79,7 @@ bool is_tdx_vm(void);
 #define is_tdx_vm() 0
 #endif /* CONFIG_TDX */
 
+void tdx_mem_init(MachineState *ms);
 void tdx_get_supported_cpuid(uint32_t function, uint32_t index, int reg,
                              uint32_t *ret);
 int tdx_pre_create_vcpu(CPUState *cpu, Error **errp);

--- a/target/i386/kvm/tdx.h
+++ b/target/i386/kvm/tdx.h
@@ -80,6 +80,8 @@ bool is_tdx_vm(void);
 #endif /* CONFIG_TDX */
 
 void tdx_mem_init(MachineState *ms);
+void tdx_init_fw_cfg(MachineState *ms);
+
 void tdx_get_supported_cpuid(uint32_t function, uint32_t index, int reg,
                              uint32_t *ret);
 int tdx_pre_create_vcpu(CPUState *cpu, Error **errp);

--- a/target/i386/kvm/tdx.h
+++ b/target/i386/kvm/tdx.h
@@ -63,6 +63,8 @@ typedef struct TdxGuest {
 
     /* GetQuote */
     TdxQuoteGenerator *quote_generator;
+
+    uint8_t num_l2_vms;
 } TdxGuest;
 
 #ifdef CONFIG_TDX

--- a/target/i386/kvm/tdx.h
+++ b/target/i386/kvm/tdx.h
@@ -65,6 +65,7 @@ typedef struct TdxGuest {
     TdxQuoteGenerator *quote_generator;
 
     uint8_t num_l2_vms;
+    MemoryRegion *bios2_region;
 } TdxGuest;
 
 #ifdef CONFIG_TDX
@@ -77,6 +78,7 @@ void tdx_get_supported_cpuid(uint32_t function, uint32_t index, int reg,
                              uint32_t *ret);
 int tdx_pre_create_vcpu(CPUState *cpu, Error **errp);
 void tdx_set_tdvf_region(MemoryRegion *tdvf_mr);
+void tdx_set_bios2_region(MemoryRegion *bios2_region);
 int tdx_parse_tdvf(void *flash_ptr, int size);
 int tdx_handle_exit(X86CPU *cpu, struct kvm_tdx_exit *tdx_exit);
 


### PR DESCRIPTION
https://github.com/coconut-svsm/qemu/pull/10 adds basic support for Intel TDX. This patchset further adds support for Intel TD-Partitioning, allowing COCONUT-SVSM to run on a TDX machine and boot a TDP guest.