### PR TITLE
Add TDP support for IGVM

### DIFF
--- a/backends/confidential-guest-support.c
+++ b/backends/confidential-guest-support.c
@@ -68,6 +68,17 @@ static int set_guest_state(hwaddr gpa, uint8_t *ptr, uint64_t len,
     return -1;
 }
 
+static int set_guest_policy(ConfidentialGuestPolicyType policy_type,
+                            uint64_t policy,
+                            void *policy_data1, uint32_t policy_data1_size,
+                            void *policy_data2, uint32_t policy_data2_size,
+                            Error **errp)
+{
+    error_setg(errp,
+               "Setting confidential guest policy is not supported for this platform");
+    return -1;
+}
+
 static int get_mem_map_entry(int index, ConfidentialGuestMemoryMapEntry *entry,
                              Error **errp)
 {
@@ -82,6 +93,7 @@ static void confidential_guest_support_init(Object *obj)
     ConfidentialGuestSupport *cgs = CONFIDENTIAL_GUEST_SUPPORT(obj);
     cgs->check_support = check_support;
     cgs->set_guest_state = set_guest_state;
+    cgs->set_guest_policy = set_guest_policy;
     cgs->get_mem_map_entry = get_mem_map_entry;
 }
 

--- a/backends/confidential-guest-support.c
+++ b/backends/confidential-guest-support.c
@@ -88,6 +88,14 @@ static int get_mem_map_entry(int index, ConfidentialGuestMemoryMapEntry *entry,
     return -1;
 }
 
+static int memory_is_shared(Error **errp)
+{
+    error_setg(
+        errp,
+        "Shared/private pages are not supported for this platform");
+    return -1;
+}
+
 static void confidential_guest_support_init(Object *obj)
 {
     ConfidentialGuestSupport *cgs = CONFIDENTIAL_GUEST_SUPPORT(obj);
@@ -95,6 +103,7 @@ static void confidential_guest_support_init(Object *obj)
     cgs->set_guest_state = set_guest_state;
     cgs->set_guest_policy = set_guest_policy;
     cgs->get_mem_map_entry = get_mem_map_entry;
+    cgs->memory_is_shared = memory_is_shared;
 }
 
 static void confidential_guest_support_finalize(Object *obj)

--- a/backends/igvm.c
+++ b/backends/igvm.c
@@ -101,17 +101,20 @@ static int directive_vp_context(struct igvm_context *ctx, int i,
 static int directive_parameter_area(struct igvm_context *ctx, int i,
                                const uint8_t *header_data, Error **errp);
 static int directive_parameter_insert(struct igvm_context *ctx, int i,
-                                const uint8_t *header_data, Error **errp);
+                               const uint8_t *header_data, Error **errp);
 static int directive_memory_map(struct igvm_context *ctx, int i,
-                                    const uint8_t *header_data, Error **errp);
+                               const uint8_t *header_data, Error **errp);
 static int directive_vp_count(struct igvm_context *ctx, int i,
-                                      const uint8_t *header_data, Error **errp);
+                               const uint8_t *header_data, Error **errp);
 static int directive_environment_info(struct igvm_context *ctx, int i,
-                                const uint8_t *header_data, Error **errp);
+                               const uint8_t *header_data, Error **errp);
 static int directive_required_memory(struct igvm_context *ctx, int i,
-                              const uint8_t *header_data, Error **errp);
+                               const uint8_t *header_data, Error **errp);
 static int directive_snp_id_block(struct igvm_context *ctx, int i,
-                                      const uint8_t *header_data, Error **errp);
+                               const uint8_t *header_data, Error **errp);
+
+static int initialization_guest_policy(struct igvm_context *ctx, int i,
+                               const uint8_t *header_data, Error **errp);
 
 struct IGVMHandler {
     uint32_t type;
@@ -130,7 +133,7 @@ static struct IGVMHandler handlers[] = {
     { IGVM_VHT_ENVIRONMENT_INFO_PARAMETER, HEADER_SECTION_DIRECTIVE, directive_environment_info },
     { IGVM_VHT_REQUIRED_MEMORY, HEADER_SECTION_DIRECTIVE, directive_required_memory },
     { IGVM_VHT_SNP_ID_BLOCK, HEADER_SECTION_DIRECTIVE, directive_snp_id_block },
-
+    { IGVM_VHT_GUEST_POLICY, HEADER_SECTION_INITIALIZATION, initialization_guest_policy },
 };
 
 static int handle(uint32_t type, struct igvm_context *ctx, int i, Error **errp)
@@ -682,6 +685,18 @@ static int directive_snp_id_block(struct igvm_context *ctx, int i,
                72);
     }
 
+    return 0;
+}
+
+static int initialization_guest_policy(struct igvm_context *ctx, int i,
+                                     const uint8_t *header_data, Error **errp)
+{
+    const IGVM_VHS_GUEST_POLICY *guest =
+        (const IGVM_VHS_GUEST_POLICY *)header_data;
+
+    if (guest->compatibility_mask & ctx->compatibility_mask) {
+        ctx->sev_policy = guest->policy;
+    }
     return 0;
 }
 

--- a/backends/igvm.c
+++ b/backends/igvm.c
@@ -465,7 +465,8 @@ static int directive_parameter_insert(struct igvm_context *ctx, int i,
 
     QTAILQ_FOREACH(param_entry, &ctx->parameter_data, next)
     {
-        if (param_entry->index == param->parameter_area_index) {
+        if (param_entry->index == param->parameter_area_index &&
+            (param->compatibility_mask & ctx->compatibility_mask)) {
             region =
                 igvm_prepare_memory(param->gpa, param_entry->size, i, errp);
             if (!region) {

--- a/backends/igvm.c
+++ b/backends/igvm.c
@@ -722,6 +722,7 @@ static int supported_platform_compat_mask(struct igvm_context *ctx,
         IgvmVariableHeaderType typ =
             igvm_get_header_type(ctx->cgs->igvm, HEADER_SECTION_PLATFORM, i);
         if (typ == IGVM_VHT_SUPPORTED_PLATFORM) {
+            bool found = false;
             header_handle =
                 igvm_get_header(ctx->cgs->igvm, HEADER_SECTION_PLATFORM, i);
             if (header_handle < 0) {
@@ -756,10 +757,13 @@ static int supported_platform_compat_mask(struct igvm_context *ctx,
                         platform->highest_vtl, platform->shared_gpa_boundary)) {
                     ctx->compatibility_mask = platform->compatibility_mask;
                     ctx->platform_type = platform->platform_type;
-                    break;
+                    found = true;
                 }
             }
             igvm_free_buffer(ctx->cgs->igvm, header_handle);
+            if (found) {
+                break;
+            }
         }
     }
     if (ctx->compatibility_mask == 0) {

--- a/backends/igvm.c
+++ b/backends/igvm.c
@@ -749,7 +749,7 @@ static int supported_platform_compat_mask(struct igvm_context *ctx,
                                                                 header_handle) +
                                                 sizeof(
                                                     IGVM_VHS_VARIABLE_HEADER));
-            /* Currently only support SEV-SNP. */
+            /* Currently only support SEV-SNP & TDX. */
             if (platform->platform_type == SEV_SNP) {
                 /*
                  * IGVM does not define a platform types of SEV or SEV_ES.
@@ -766,6 +766,14 @@ static int supported_platform_compat_mask(struct igvm_context *ctx,
                         platform->highest_vtl, platform->shared_gpa_boundary) ||
                     ctx->cgs->check_support(
                         CGS_PLATFORM_SEV, platform->platform_version,
+                        platform->highest_vtl, platform->shared_gpa_boundary)) {
+                    ctx->compatibility_mask = platform->compatibility_mask;
+                    ctx->platform_type = platform->platform_type;
+                    found = true;
+                }
+            } else if (platform->platform_type == TDX) {
+                if (ctx->cgs->check_support(
+                        CGS_PLATFORM_TDP, platform->platform_version,
                         platform->highest_vtl, platform->shared_gpa_boundary)) {
                     ctx->compatibility_mask = platform->compatibility_mask;
                     ctx->platform_type = platform->platform_type;

--- a/hw/i386/pc_sysfw.c
+++ b/hw/i386/pc_sysfw.c
@@ -231,13 +231,8 @@ void pc_system_firmware_init(PCMachineState *pcms,
     }
 
     if (!pflash_blk[0]) {
-        /*
-         * Machine property pflash0 not set, use ROM mode unless using IGVM,
-         * in which case the firmware must be provided by the IGVM file.
-         */
-        if (!cgs_is_igvm(MACHINE(pcms)->cgs)) {
-            x86_bios_rom_init(MACHINE(pcms), "bios.bin", pcms->firmware2, rom_memory, false);
-        }
+        /* Machine property pflash0 not set, use ROM mode */
+        x86_bios_rom_init(MACHINE(pcms), "bios.bin", pcms->firmware2, rom_memory, false);
     } else {
         if (kvm_enabled() && !kvm_readonly_mem_enabled()) {
             /*

--- a/hw/i386/x86.c
+++ b/hw/i386/x86.c
@@ -1144,6 +1144,14 @@ void x86_bios_rom_init(MachineState *ms, const char *default_firmware,
     int bios_size, bios2_size = 0, isa_bios_size;
     ssize_t ret;
 
+    if (cgs_is_igvm(ms->cgs)) {
+        /* When using IGVM, the firmware must be provided by the IGVM file */
+        if (is_tdx_vm()) {
+            tdx_initialize_igvm();
+        }
+        return;
+    }
+
     /* BIOS load */
     bios_name = ms->firmware ?: default_firmware;
     filename = qemu_find_file(QEMU_FILE_TYPE_BIOS, bios_name);

--- a/include/exec/confidential-guest-support.h
+++ b/include/exec/confidential-guest-support.h
@@ -67,6 +67,10 @@ typedef enum ConfidentialGuestPageType {
     CGS_PAGE_TYPE_REQUIRED_MEMORY,
 } ConfidentialGuestPageType;
 
+typedef enum ConfidentialGuestPolicyType {
+    GUEST_POLICY_SEV,
+} ConfidentialGuestPolicyType;
+
 struct ConfidentialGuestSupport {
     Object parent;
 
@@ -134,6 +138,23 @@ struct ConfidentialGuestSupport {
     int (*set_guest_state)(hwaddr gpa, uint8_t *ptr, uint64_t len,
                            ConfidentialGuestPageType memory_type,
                            uint16_t cpu_index, Error **errp);
+
+    /*
+     * Set the guest policy. The policy can be used to configure the
+     * confidential platform, such as if debug is enabled or not and can contain
+     * information about expected launch measurements, signed verification of
+     * guest configuration and other platform data.
+     *
+     * The format of the policy data is specific to each platform. For example,
+     * SEV-SNP uses a policy bitfield in the 'policy' argument and provides an
+     * ID block and ID authentication in the 'policy_data' parameters. The type
+     * of policy data is identified by the 'policy_type' argument.
+     */
+    int (*set_guest_policy)(ConfidentialGuestPolicyType policy_type,
+                            uint64_t policy,
+                            void *policy_data1, uint32_t policy_data1_size,
+                            void *policy_data2, uint32_t policy_data2_size,
+                            Error **errp);
 
     /*
      * Iterate the system memory map, getting the entry with the given index

--- a/include/exec/confidential-guest-support.h
+++ b/include/exec/confidential-guest-support.h
@@ -164,6 +164,13 @@ struct ConfidentialGuestSupport {
      */
     int (*get_mem_map_entry)(int index, ConfidentialGuestMemoryMapEntry *entry,
                              Error **errp);
+
+    /*
+     * Returns 1 if memory pages start as shared pages.
+     * Returns 0 if memory pages start as private pages.
+     * Returns -1 on error.
+     */
+    int (*memory_is_shared)(Error **errp);
 };
 
 typedef struct ConfidentialGuestSupportClass {

--- a/include/exec/confidential-guest-support.h
+++ b/include/exec/confidential-guest-support.h
@@ -41,6 +41,7 @@ typedef enum ConfidentialGuestPlatformType {
     CGS_PLATFORM_SEV,
     CGS_PLATFORM_SEV_ES,
     CGS_PLATFORM_SEV_SNP,
+    CGS_PLATFORM_TDP,
 } ConfidentialGuestPlatformType;
 
 typedef enum ConfidentialGuestMemoryType {

--- a/include/hw/i386/tdvf.h
+++ b/include/hw/i386/tdvf.h
@@ -33,7 +33,7 @@
 #define TDVF_SECTION_ATTRIBUTES_PAGE_AUG    (1U << 1)
 
 typedef struct TdxFirmwareEntry {
-    uint32_t data_offset;
+    uint64_t data_offset;
     uint32_t data_len;
     uint64_t address;
     uint64_t size;
@@ -56,5 +56,7 @@ typedef struct TdxFirmware {
     for (e = (fw)->entries; e != (fw)->entries + (fw)->nr_entries; e++)
 
 int tdvf_parse_metadata(TdxFirmware *fw, void *flash_ptr, int size);
+int tdvf_initialize_igvm(TdxFirmware *fw);
+int tdvf_add_metadata(TdxFirmware *fw, TdxFirmwareEntry *entry);
 
 #endif /* HW_I386_TDVF_H */

--- a/qapi/qom.json
+++ b/qapi/qom.json
@@ -998,6 +998,7 @@
 # Since: 9.0
 ##
 { 'struct': 'TdxGuestProperties',
+  'base': 'ConfidentialGuestProperties',
   'data': { '*sept-ve-disable': 'bool',
             '*mrconfigid': 'str',
             '*mrowner': 'str',

--- a/target/i386/kvm/tdx-stub.c
+++ b/target/i386/kvm/tdx-stub.c
@@ -12,6 +12,11 @@ int tdx_parse_tdvf(void *flash_ptr, int size)
     return -EINVAL;
 }
 
+int tdx_initialize_igvm(void)
+{
+    return -EINVAL;
+}
+
 int tdx_handle_exit(X86CPU *cpu, struct kvm_tdx_exit *tdx_exit)
 {
     return -EINVAL;

--- a/target/i386/kvm/tdx.c
+++ b/target/i386/kvm/tdx.c
@@ -1008,6 +1008,12 @@ int tdx_parse_tdvf(void *flash_ptr, int size)
     return tdvf_parse_metadata(&tdx_guest->tdvf, flash_ptr, size);
 }
 
+
+int tdx_initialize_igvm(void)
+{
+    return tdvf_initialize_igvm(&tdx_guest->tdvf);
+}
+
 static void tdx_inject_interrupt(uint32_t apicid, uint32_t vector)
 {
     int ret;

--- a/target/i386/kvm/tdx.h
+++ b/target/i386/kvm/tdx.h
@@ -88,6 +88,7 @@ int tdx_pre_create_vcpu(CPUState *cpu, Error **errp);
 void tdx_set_tdvf_region(MemoryRegion *tdvf_mr);
 void tdx_set_bios2_region(MemoryRegion *bios2_region);
 int tdx_parse_tdvf(void *flash_ptr, int size);
+int tdx_initialize_igvm(void);
 int tdx_handle_exit(X86CPU *cpu, struct kvm_tdx_exit *tdx_exit);
 
 #endif /* QEMU_I386_TDX_H */

--- a/target/i386/sev.c
+++ b/target/i386/sev.c
@@ -433,7 +433,7 @@ static void sev_apply_cpu_context(CPUState *cpu)
                 launch_vmsa->vmsa.ss.base, launch_vmsa->vmsa.ss.limit,
                 FLAGS_VMSA_TO_SEGCACHE(launch_vmsa->vmsa.ss.attrib));
 
-            env->dr[6] = launch_vmsa->vmsa.dr6;
+                        env->dr[6] = launch_vmsa->vmsa.dr6;
             env->dr[7] = launch_vmsa->vmsa.dr7;
 
             env->regs[R_EAX] = launch_vmsa->vmsa.rax;
@@ -482,7 +482,7 @@ static int check_vmsa_supported(const struct sev_es_save_area *vmsa)
     memset(&vmsa_check.ds, 0, sizeof(vmsa_check.ds));
     memset(&vmsa_check.fs, 0, sizeof(vmsa_check.fs));
     memset(&vmsa_check.gs, 0, sizeof(vmsa_check.gs));
-    vmsa_check.efer = 0;
+        vmsa_check.efer = 0;
     vmsa_check.cr0 = 0;
     vmsa_check.cr3 = 0;
     vmsa_check.cr4 = 0;
@@ -667,6 +667,83 @@ out:
     return ret;
 }
 
+static int cgs_set_guest_policy(ConfidentialGuestPolicyType policy_type,
+                            uint64_t policy,
+                            void *policy_data1, uint32_t policy_data1_size,
+                            void *policy_data2, uint32_t policy_data2_size,
+                            Error **errp)
+{
+    if (policy_type != GUEST_POLICY_SEV) {
+        error_setg(errp, "%s: Invalid guest policy type provided for SEV: %d",
+        __func__, policy_type);
+        return -1;
+    }
+    /*
+     * SEV-SNP handles policy differently. The policy flags are defined in
+     * kvm_start_conf.policy and an ID block and ID auth can be provided.
+     */
+    if (sev_snp_enabled()) {
+        SevSnpGuestState *sev_snp_guest = SEV_SNP_GUEST(MACHINE(qdev_get_machine())->cgs);
+        struct kvm_sev_snp_launch_finish *finish = &sev_snp_guest->kvm_finish_conf;
+
+        /*
+        * The policy consists of flags in 'policy' and optionally an ID block and
+        * ID auth in policy_data1 and policy_data2 respectively.
+        * The ID block and auth are optional so clear any previous ID block and
+        * auth and set them if provided, but always set the policy flags.
+        */
+        g_free(sev_snp_guest->id_block);
+        g_free((guchar *)finish->id_block_uaddr);
+        g_free(sev_snp_guest->id_auth);
+        g_free((guchar *)finish->id_auth_uaddr);
+        sev_snp_guest->id_block = NULL;
+        finish->id_block_uaddr = 0;
+        sev_snp_guest->id_auth = NULL;
+        finish->id_auth_uaddr = 0;
+
+        if (policy_data1_size > 0) {
+            struct sev_snp_id_authentication *id_auth = (struct sev_snp_id_authentication *)policy_data2;
+
+            if (policy_data1_size != KVM_SEV_SNP_ID_BLOCK_SIZE) {
+                error_setg(errp, "%s: Invalid SEV-SNP ID block: incorrect size",
+                        __func__);
+                return -1;
+            }
+            if (policy_data2_size != KVM_SEV_SNP_ID_AUTH_SIZE) {
+                error_setg(errp, "%s: Invalid SEV-SNP ID auth block: incorrect size",
+                        __func__);
+                return -1;
+            }
+            finish->id_block_uaddr = (__u64)g_malloc0(KVM_SEV_SNP_ID_BLOCK_SIZE);
+            finish->id_auth_uaddr = (__u64)g_malloc0(KVM_SEV_SNP_ID_AUTH_SIZE);
+            memcpy((void *)finish->id_block_uaddr, policy_data1, KVM_SEV_SNP_ID_BLOCK_SIZE);
+            memcpy((void *)finish->id_auth_uaddr, policy_data2, KVM_SEV_SNP_ID_AUTH_SIZE);
+
+            /*
+             * Check if an author key has been provided and use that to flag
+             * whether the author key is enabled. The first of the author key
+             * must be non-zero to indicate the key type, which will currently
+             * always be 2.
+             */
+            sev_snp_guest->kvm_finish_conf.auth_key_en =
+                    id_auth->author_key[0] ? 1 : 0;
+            finish->id_block_en = 1;
+        }
+        sev_snp_guest->kvm_start_conf.policy = policy;
+    }
+    else {
+        SevGuestState *sev_guest = SEV_GUEST(MACHINE(qdev_get_machine())->cgs);
+        /* Only the policy flags are supported for SEV and SEV-ES */
+        if ((policy_data1_size > 0) || (policy_data2_size > 0) || !sev_guest) {
+            error_setg(errp, "%s: An ID block/ID auth block has been provided "
+                             "but SEV-SNP is not supported", __func__);
+            return -1;
+        }
+        sev_guest->policy = policy;
+    }
+    return 0;
+}
+
 static int cgs_get_mem_map_entry(int index,
                                  ConfidentialGuestMemoryMapEntry *entry,
                                  Error **errp)
@@ -749,6 +826,7 @@ sev_common_instance_init(Object *obj)
 
     cgs->check_support = cgs_check_support;
     cgs->set_guest_state = cgs_set_guest_state;
+    cgs->set_guest_policy = cgs_set_guest_policy;
     cgs->get_mem_map_entry = cgs_get_mem_map_entry;
 
     QTAILQ_INIT(&sev_common->launch_vmsa);

--- a/target/i386/sev.c
+++ b/target/i386/sev.c
@@ -773,6 +773,11 @@ static int cgs_get_mem_map_entry(int index,
     return 0;
 }
 
+static int cgs_memory_is_shared(Error **errp)
+{
+    return 1;
+}
+
 static char *
 sev_common_get_sev_device(Object *obj, Error **errp)
 {
@@ -828,6 +833,7 @@ sev_common_instance_init(Object *obj)
     cgs->set_guest_state = cgs_set_guest_state;
     cgs->set_guest_policy = cgs_set_guest_policy;
     cgs->get_mem_map_entry = cgs_get_mem_map_entry;
+    cgs->memory_is_shared = cgs_memory_is_shared;
 
     QTAILQ_INIT(&sev_common->launch_vmsa);
 }

--- a/target/i386/sev.h
+++ b/target/i386/sev.h
@@ -155,6 +155,18 @@ struct QEMU_PACKED sev_es_save_area {
 	uint8_t fpreg_ymm[256];
 };
 
+struct QEMU_PACKED sev_snp_id_authentication {
+	uint32_t id_key_alg;
+	uint32_t auth_key_algo;
+	uint8_t reserved[56];
+	uint8_t id_block_sig[512];
+	uint8_t id_key[1028];
+	uint8_t reserved2[60];
+	uint8_t id_key_sig[512];
+	uint8_t author_key[1028];
+	uint8_t reserved3[892];
+};
+
 #ifdef CONFIG_SEV
 bool sev_enabled(void);
 bool sev_es_enabled(void);


### PR DESCRIPTION
This patchset adds TDP support for IGVM mode in host QEMU. The usage mirrors its SEV counterpart (`igvm-file=...`).

TDP only supports a subset of the existing IGVM directives. Internally, we translate IGVM directives into TDX fw metadata so that they can be processed the same way as TDVF during finalization.