### PR TITLE
nocc: build it only when CONFIG_SEV is defined

### DIFF
--- a/target/i386/meson.build
+++ b/target/i386/meson.build
@@ -5,9 +5,8 @@ i386_ss.add(files(
   'helper.c',
   'xsave_helper.c',
   'cpu-dump.c',
-  'nocc.c',
 ))
-i386_ss.add(when: 'CONFIG_SEV', if_true: files('host-cpu.c', 'confidential-guest.c'))
+i386_ss.add(when: 'CONFIG_SEV', if_true: files('host-cpu.c', 'confidential-guest.c', 'nocc.c'))
 
 # x86 cpu type
 i386_ss.add(when: 'CONFIG_KVM', if_true: files('host-cpu.c'))


### PR DESCRIPTION
This is a temporary workaround to avoid a build problem with qemu-user since nocc.c depends on confidential-guest.c.

In the long run we will reorganize the code to avoid the dependency and compile nocc.c without CONFIG_SEV.

Reported-by: Luigi Leonardi <leonardi@redhat.com>
Closes: https://github.com/coconut-svsm/svsm/issues/665
Fixes: 06c04988ba ("load state from igvm for non-cc VMs")