### PR TITLE
Create communication channel between two SVSM

### DIFF
--- a/hmp-commands.hx
+++ b/hmp-commands.hx
@@ -328,6 +328,34 @@ SRST
 ERST
 
     {
+        .name       = "snp_migrate",
+        .args_type  = "uri:s,address:o/h",
+        .params     = "uri address",
+        .help       = "Start SNP migration. Send migration data to uri.",
+        .cmd        = hmp_snp_migrate,
+    },
+
+SRST
+``snp_migrate`` *uri* *address*
+  Read migration data from migration page at *address* and send them through
+  channel specified by *uri*.
+ERST
+
+    {
+        .name       = "snp_migrate_incoming",
+        .args_type  = "uri:s,address:o/h",
+        .params     = "uri address",
+        .help       = "Listen on address for incoming SNP migration.",
+        .cmd        = hmp_snp_migrate_incoming,
+    },
+
+SRST
+``snp_migrate_incoming`` *uri* *address*
+  Listen for migration data on channel specified by *uri* and forward them to
+  migration page at *address*.
+ERST
+
+    {
         .name       = "savevm",
         .args_type  = "name:s?",
         .params     = "tag",

--- a/include/monitor/hmp.h
+++ b/include/monitor/hmp.h
@@ -60,6 +60,8 @@ void hmp_balloon(Monitor *mon, const QDict *qdict);
 void hmp_loadvm(Monitor *mon, const QDict *qdict);
 void hmp_savevm(Monitor *mon, const QDict *qdict);
 void hmp_delvm(Monitor *mon, const QDict *qdict);
+void hmp_snp_migrate(Monitor *mon, const QDict *qdict);
+void hmp_snp_migrate_incoming(Monitor *mon, const QDict *qdict);
 void hmp_migrate_cancel(Monitor *mon, const QDict *qdict);
 void hmp_migrate_continue(Monitor *mon, const QDict *qdict);
 void hmp_migrate_incoming(Monitor *mon, const QDict *qdict);

--- a/include/qemu/typedefs.h
+++ b/include/qemu/typedefs.h
@@ -109,6 +109,7 @@ typedef struct Range Range;
 typedef struct ReservedRegion ReservedRegion;
 typedef struct SHPCDevice SHPCDevice;
 typedef struct SSIBus SSIBus;
+typedef struct SnpMigrationState SnpMigrationState;
 typedef struct TCGCPUOps TCGCPUOps;
 typedef struct TCGHelperInfo TCGHelperInfo;
 typedef struct TaskState TaskState;

--- a/migration/meson.build
+++ b/migration/meson.build
@@ -28,6 +28,7 @@ system_ss.add(files(
   'postcopy-ram.c',
   'savevm.c',
   'socket.c',
+  'snp.c',
   'tls.c',
   'threadinfo.c',
 ), gnutls, zlib)

--- a/migration/migration-hmp-cmds.c
+++ b/migration/migration-hmp-cmds.c
@@ -16,6 +16,7 @@
 #include "qemu/osdep.h"
 #include "block/qapi.h"
 #include "migration/snapshot.h"
+#include "migration/snp.h"
 #include "monitor/hmp.h"
 #include "monitor/monitor.h"
 #include "qapi/error.h"
@@ -394,6 +395,48 @@ void hmp_delvm(Monitor *mon, const QDict *qdict)
     const char *name = qdict_get_str(qdict, "name");
 
     delete_snapshot(name, false, NULL, &err);
+    hmp_handle_error(mon, err);
+}
+
+void hmp_snp_migrate(Monitor *mon, const QDict *qdict)
+{
+    Error *err = NULL;
+    const char *uri = qdict_get_str(qdict, "uri");
+    uint64_t address = qdict_get_int(qdict, "address");
+    address = address >> 20; // FIXME: shifted value is obtained. Correcting.
+    MigrationChannelList *caps = NULL;
+    g_autoptr(MigrationChannel) channel = NULL;
+
+    if (!migrate_uri_parse(uri, &channel, &err)) {
+        goto end;
+    }
+    QAPI_LIST_PREPEND(caps, g_steal_pointer(&channel));
+
+    snp_migrate(caps, address, false, &err);
+    qapi_free_MigrationChannelList(caps);
+
+end:
+    hmp_handle_error(mon, err);
+}
+
+void hmp_snp_migrate_incoming(Monitor *mon, const QDict *qdict)
+{
+    Error *err = NULL;
+    const char *uri = qdict_get_str(qdict, "uri");
+    int64_t address = qdict_get_int(qdict, "address");
+    address = address >> 20; // FIXME: shifted value is obtained. Correcting.
+    MigrationChannelList *caps = NULL;
+    g_autoptr(MigrationChannel) channel = NULL;
+
+    if (!migrate_uri_parse(uri, &channel, &err)) {
+        goto end;
+    }
+    QAPI_LIST_PREPEND(caps, g_steal_pointer(&channel));
+
+    snp_migrate(caps, address, true, &err);
+    qapi_free_MigrationChannelList(caps);
+
+end:
     hmp_handle_error(mon, err);
 }
 

--- a/migration/snp.c
+++ b/migration/snp.c
@@ -1,0 +1,227 @@
+/*
+ * QEMU SEV-SNP confidential machine migration
+ *
+ * Authors:
+ *  Jakub Růžička <jakub.ruzicka@matfyz.cz>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2 or later.
+ * See the COPYING file in the top-level directory.
+ */
+#include "qemu/osdep.h"
+#include "qemu-file.h"
+#include "qemu/main-loop.h"
+#include "io/channel-socket.h"
+#include "snp.h"
+#include "trace.h"
+#include "qapi/error.h"
+
+static SnpMigrationState current_snp_migration;
+
+static void write_status_register(uint8_t value) {
+    SnpMigrationState *s = &current_snp_migration;
+    uint64_t pa = s->migration_page_addr + STATUS_REGISTER_OFFSET;
+    uint8_t buf[1] = {value};
+    cpu_physical_memory_write(pa, buf, 1);
+}
+
+static uint8_t read_status_register(void) {
+    SnpMigrationState *s = &current_snp_migration;
+    uint64_t pa = s->migration_page_addr + STATUS_REGISTER_OFFSET;
+    uint8_t buf[1] = {0};
+    cpu_physical_memory_read(pa, buf, 1);
+    return buf[0];
+}
+
+static void write_data_register(uint8_t value) {
+    SnpMigrationState *s = &current_snp_migration;
+    uint64_t pa = s->migration_page_addr + DATA_REGISTER_OFFSET;
+    uint8_t buf[1] = {value};
+    cpu_physical_memory_write(pa, buf, 1);
+}
+
+static uint8_t read_data_register(void) {
+    SnpMigrationState *s = &current_snp_migration;
+    uint64_t pa = s->migration_page_addr + DATA_REGISTER_OFFSET;
+    uint8_t buf[1] = {0};
+    cpu_physical_memory_read(pa, buf, 1);
+    return buf[0];
+}
+
+static void read_page_buffer(uint8_t *buffer) {
+    SnpMigrationState *s = &current_snp_migration;
+    uint64_t pa = s->migration_page_addr + DATA_BUFFER_OFFSET;
+    cpu_physical_memory_read(pa, buffer, DATA_BUFFER_SIZE);
+}
+
+static void write_page_buffer(uint8_t *buffer, size_t size) {
+    SnpMigrationState *s = &current_snp_migration;
+    uint64_t pa = s->migration_page_addr + DATA_BUFFER_OFFSET;
+    cpu_physical_memory_write(pa, buffer, size);
+}
+
+static void
+*snp_process_migration_incoming(void *opaque) {
+    SnpMigrationState *s = opaque;
+    QEMUFile *f = s->migration_stream;
+    write_status_register(SNP_MIGRATION_STATUS_INCOMING);
+    /* Setting data_register to SNP_MIGRATION_DATA_READ in order to start with a
+     * known state of data register and allow writing fist data. Otherwise
+     * deadlock is possible as the loop below waits for data_register to
+     * contain SNP_MIGRATION_DATA_READ value in order to not override data that
+     * SVSM did not yet processed.
+     */
+    write_data_register(SNP_MIGRATION_DATA_READ);
+    uint64_t header = qemu_get_be64(f);
+    while (header != SNP_MIGRATION_FLAG_COMPLETED) {
+        switch (header) {
+            case SNP_MIGRATION_FLAG_DATA:
+                uint8_t buffer[DATA_BUFFER_SIZE] = {0};
+                qemu_get_buffer(f, buffer, DATA_BUFFER_SIZE);
+                uint8_t data;
+                // Wait for the latest written page to be processed.
+                do {
+                    data = read_data_register();
+                } while (data != SNP_MIGRATION_DATA_READ);
+                write_page_buffer(buffer, DATA_BUFFER_SIZE);
+                write_data_register(SNP_MIGRATION_DATA_READY);
+                break;;
+            default:
+                qemu_log("Unknown header %ld:", header);
+        }
+        header = qemu_get_be64(f);
+    }
+    qemu_fclose(f);
+    for(int i = 0; i < s->channels_len; i++) {
+        object_unref(OBJECT(s->channels[i]));
+    }
+    return NULL;
+}
+
+static void
+*snp_process_migration(void *opaque) {
+    SnpMigrationState *s = opaque;
+    QEMUFile *f = s->migration_stream;
+    /* Set the data_register to a known state before starting the migration */
+    write_data_register(SNP_MIGRATION_DATA_READ);
+    write_status_register(SNP_MIGRATION_STATUS_RUNNING);
+
+    uint8_t status;
+    do {
+        status = read_status_register();
+        if (read_data_register() == SNP_MIGRATION_DATA_READY) {
+            uint8_t buffer[DATA_BUFFER_SIZE] = {0};
+            read_page_buffer(buffer);
+            write_data_register(SNP_MIGRATION_DATA_READ);
+
+            qemu_put_be64(f, SNP_MIGRATION_FLAG_DATA);
+            qemu_put_buffer(f, buffer, DATA_BUFFER_SIZE);
+        }
+    } while (status != SNP_MIGRATION_STATUS_COMPLETED);
+    qemu_put_be64(f, SNP_MIGRATION_FLAG_COMPLETED);
+    qemu_fflush(f);
+    uint64_t transferred = qemu_file_transferred(f);
+    qemu_log("Bytes transferred: %ld\n", transferred);
+    qemu_fclose(f);
+    for(int i = 0; i < s->channels_len; i++) {
+        object_unref(OBJECT(s->channels[i]));
+    }
+    return NULL;
+}
+
+void snp_migrate_socket(SocketAddress *saddr, Error **errp) {
+    QIOChannelSocket *sioc = qio_channel_socket_new();
+    if (qio_channel_socket_connect_sync(sioc, saddr, errp) < 0) {
+        error_report("Connection to the destinatino socket failed");
+        return;
+    }
+    QIOChannel *ioc = QIO_CHANNEL(sioc);
+    QEMUFile *f = qemu_file_new_output(ioc);
+    if (!f) {
+        error_report("Failed to create QEMUFile from channel");
+        return;
+    }
+    SnpMigrationState *state = &current_snp_migration;
+    state->migration_stream = f;
+    state->channels[0] = ioc;
+    state->channels_len = 1;
+
+    QemuThread thread;
+    qemu_thread_create(&thread, "snp_worker", snp_process_migration, state, QEMU_THREAD_JOINABLE);
+}
+
+void snp_migrate_socket_incoming(SocketAddress *saddr, Error **errp) 
+{
+    QIOChannelSocket *listener = qio_channel_socket_new();
+
+    if (qio_channel_socket_listen_sync(listener, saddr, 1, errp) < 0) {
+        error_report("Listening for migration on socket failed");
+        return;
+    }
+
+    QIOChannelSocket *sioc = qio_channel_socket_accept(listener, errp);
+    if (!sioc) {
+        return;
+    }
+
+    QIOChannel *ioc = QIO_CHANNEL(sioc);
+    QEMUFile *f = qemu_file_new_input(ioc);
+    if (!f) {
+        error_report("Failed to create QEMUFile from channel");
+        return;
+    }
+    SnpMigrationState *state = &current_snp_migration;
+    state->migration_stream = f;
+    state->channels[0] = ioc;
+    state->channels[1] = listener;
+    state->channels_len = 2;
+
+    QemuThread thread;
+    qemu_thread_create(&thread, "snp_worker", snp_process_migration_incoming, state, QEMU_THREAD_JOINABLE);
+}
+
+
+void snp_migrate(MigrationChannelList *channels, int64_t migration_page_addr, bool incoming, Error **errp){
+    MigrationAddress *addr = NULL;
+
+    if (!channels) {
+        error_setg(errp, "Channel list must be non-empty");
+        return;
+    }
+
+    if (channels) {
+        /* To verify that Migrate channel list has only item */
+        if (channels->next) {
+            error_setg(errp, "Channel list has more than one entries");
+            return;
+        }
+        addr = channels->value->addr;
+    }
+    SnpMigrationState *state = &current_snp_migration;
+    state->migration_page_addr = migration_page_addr;
+    state->incoming = incoming;
+
+    if (addr->transport == MIGRATION_ADDRESS_TYPE_SOCKET) {
+        SocketAddress *saddr = &addr->u.socket;
+        if (saddr->type == SOCKET_ADDRESS_TYPE_INET ||
+            saddr->type == SOCKET_ADDRESS_TYPE_UNIX ||
+            saddr->type == SOCKET_ADDRESS_TYPE_VSOCK) {
+            if (incoming) {
+                snp_migrate_socket_incoming(saddr, errp);
+            } else {
+                snp_migrate_socket(saddr, errp);
+            }
+        } else if (saddr->type == SOCKET_ADDRESS_TYPE_FD) {
+            error_setg(errp, "fd is currently not implemented");
+        }
+#ifdef CONFIG_RDMA
+    } else if (addr->transport == MIGRATION_ADDRESS_TYPE_RDMA) {
+        error_setg(errp, "rdma is currently not implemented");
+#endif
+    } else if (addr->transport == MIGRATION_ADDRESS_TYPE_EXEC) {
+        error_setg(errp, "exec is currently not implemented");
+    } else if (addr->transport == MIGRATION_ADDRESS_TYPE_FILE) {
+        error_setg(errp, "file is currently not implemented");
+    } else {
+        error_setg(errp, "unknown migration protocol");
+    }
+}

--- a/migration/snp.h
+++ b/migration/snp.h
@@ -1,0 +1,46 @@
+/*
+ * QEMU SEV-SNP confidential machine migration
+ *
+ * Authors:
+ *  Jakub Růžička <jakub.ruzicka@matfyz.cz>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2 or later.
+ * See the COPYING file in the top-level directory.
+ */
+#ifndef MIGRATION_SNP_H
+#define MIGRATION_SNP_H
+
+#include "migration/migration.h"
+
+// Used in communication with SVSM
+#define SNP_MIGRATION_STATUS_NOT_STARTED 0x0
+#define SNP_MIGRATION_STATUS_INCOMING 0x1
+#define SNP_MIGRATION_STATUS_RUNNING 0x2
+#define SNP_MIGRATION_STATUS_COMPLETED 0x3
+
+#define SNP_MIGRATION_DATA_READY 0x4
+#define SNP_MIGRATION_DATA_READ 0x5
+
+// Used in communication with the other QEMU
+#define SNP_MIGRATION_FLAG_DATA 0x5
+#define SNP_MIGRATION_FLAG_COMPLETED 0x6
+
+#define STATUS_REGISTER_OFFSET 0x0
+#define DATA_REGISTER_OFFSET 0x1
+#define DATA_BUFFER_OFFSET 0x800
+#define DATA_BUFFER_SIZE 0x800
+
+struct SnpMigrationState { 
+    bool incoming;
+    QEMUFile *migration_stream;
+    uint64_t migration_page_addr;
+
+    int channels_len; // Store them to free them at the end 
+    void *channels[]; // Store them to free them at the end 
+};
+
+void snp_migrate(MigrationChannelList *channels, int64_t migration_page_addr, bool incoming, Error **errp);
+void snp_migrate_socket(SocketAddress *saddr, Error **errp);
+void snp_migrate_socket_incoming(SocketAddress *saddr, Error **errp);
+
+#endif


### PR DESCRIPTION
This proof of concept introduces two new commands, `snp_migrate <uri> <address>` and `snp_migrate_incoming <uri> <address>`, that together create a communication channel over which the SVSM instances can send the migration data.

The first argument specifies the communication channel. Currently, only sockets are supported. The migration data and commands are read from migration page, which is a single shared page, whose address is provided as a second argument.

Migration page has the following structure:
```
--------------------------------------------------------------------------
Offset   Size    Name                Notes
--------------------------------------------------------------------------
0x0      0x1     status register     Used to communicate the current
                                     status of migration: not started,
                                     incoming, running, completed.
0x1      0x1     data register       Used to communicate data
                                     availability: data ready, data
                                     read.
0x2      0x7FD   reserved
0x800    0x800   data buffer         Used for data transfer between QEMU
                                     and SVSM.
--------------------------------------------------------------------------
```
The hypervisor is deemed untrusted in a confidential computing scenario. Therefore, the only thing we want from the hypervisor is to provide a communication channel over which the SVSM instances can communicate without implementing the network stack. This patch should accomplish just that. The rest of the work should be done in the SVSM.