### PR TITLE
Use IGVM parameter to pass MADT

### DIFF
--- a/backends/igvm.c
+++ b/backends/igvm.c
@@ -91,6 +91,7 @@ typedef struct QIgvm {
     unsigned region_last_index;
     unsigned region_page_count;
     bool only_vp_context;
+    GArray *madt;
 } QIgvm;
 
 static int qigvm_directive_page_data(QIgvm *ctx, const uint8_t *header_data,
@@ -118,6 +119,8 @@ static int qigvm_directive_snp_id_block(QIgvm *ctx, const uint8_t *header_data,
 static int qigvm_initialization_guest_policy(QIgvm *ctx,
                                        const uint8_t *header_data,
                                        Error **errp);
+static int qigvm_initialization_madt(QIgvm *ctx,
+                                     const uint8_t *header_data, Error **errp);
 
 struct QIGVMHandler {
     uint32_t type;
@@ -146,6 +149,8 @@ static struct QIGVMHandler handlers[] = {
       qigvm_directive_snp_id_block },
     { IGVM_VHT_GUEST_POLICY, IGVM_HEADER_SECTION_INITIALIZATION,
       qigvm_initialization_guest_policy },
+    { IGVM_VHT_MADT, IGVM_HEADER_SECTION_DIRECTIVE,
+      qigvm_initialization_madt },
 };
 
 static int qigvm_handler(QIgvm *ctx, uint32_t type, Error **errp)
@@ -790,6 +795,34 @@ static int qigvm_initialization_guest_policy(QIgvm *ctx,
     return 0;
 }
 
+static int qigvm_initialization_madt(QIgvm *ctx,
+                                     const uint8_t *header_data, Error **errp)
+{
+    const IGVM_VHS_PARAMETER *param = (const IGVM_VHS_PARAMETER *)header_data;
+    QIgvmParameterData *param_entry;
+
+    if (ctx->madt == NULL) {
+        return 0;
+    }
+
+    /* Find the parameter area that should hold the device tree */
+    QTAILQ_FOREACH(param_entry, &ctx->parameter_data, next)
+    {
+        if (param_entry->index == param->parameter_area_index) {
+
+            if (ctx->madt->len > param_entry->size) {
+                error_setg(
+                    errp,
+                    "IGVM: MADT size exceeds parameter area defined in IGVM file");
+                return -1;
+            }
+            memcpy(param_entry->data, ctx->madt->data, ctx->madt->len);
+            break;
+        }
+    }
+    return 0;
+}
+
 static int qigvm_supported_platform_compat_mask(QIgvm *ctx, Error **errp)
 {
     int32_t header_count;
@@ -915,7 +948,7 @@ static IgvmHandle qigvm_file_init(char *filename, Error **errp)
     return igvm;
 }
 
-int qigvm_process_file(IgvmCfg *cfg, ConfidentialGuestSupport *cgs,
+int qigvm_process_file(IgvmCfg *cfg, ConfidentialGuestSupport *cgs, GArray *madt,
                        bool onlyVpContext, Error **errp)
 {
     int32_t header_count;
@@ -937,6 +970,8 @@ int qigvm_process_file(IgvmCfg *cfg, ConfidentialGuestSupport *cgs,
      */
     ctx.cgs = cgs;
     ctx.cgsc = cgs ? CONFIDENTIAL_GUEST_SUPPORT_GET_CLASS(cgs) : NULL;
+
+    ctx.madt = madt;
 
     /*
      * Check that the IGVM file provides configuration for the current

--- a/backends/igvm.h
+++ b/backends/igvm.h
@@ -16,7 +16,7 @@
 #include "system/igvm-cfg.h"
 #include "qapi/error.h"
 
-int qigvm_process_file(IgvmCfg *igvm, ConfidentialGuestSupport *cgs,
+int qigvm_process_file(IgvmCfg *igvm, ConfidentialGuestSupport *cgs, GArray *madt,
                       bool onlyVpContext, Error **errp);
 
 #endif

--- a/hw/acpi/aml-build.c
+++ b/hw/acpi/aml-build.c
@@ -1748,8 +1748,11 @@ void acpi_table_end(BIOSLinker *linker, AcpiTable *desc)
      */
     memcpy(len_ptr, &table_len_le, sizeof table_len_le);
 
-    bios_linker_loader_add_checksum(linker, ACPI_BUILD_TABLE_FILE,
-        desc->table_offset, table_len, desc->table_offset + checksum_offset);
+    if (linker != NULL) {
+        bios_linker_loader_add_checksum(linker, ACPI_BUILD_TABLE_FILE,
+                                        desc->table_offset, table_len,
+                                        desc->table_offset + checksum_offset);
+    }
 }
 
 void *acpi_data_push(GArray *table_data, unsigned size)

--- a/hw/i386/acpi-build.c
+++ b/hw/i386/acpi-build.c
@@ -2236,3 +2236,11 @@ void acpi_setup(void)
      */
     acpi_build_tables_cleanup(&tables, false);
 }
+
+GArray *acpi_build_madt_standalone(MachineState *machine) {
+  X86MachineState *x86ms = X86_MACHINE(machine);
+  GArray *table = g_array_new(false, true, 1);
+  acpi_build_madt(table, NULL, x86ms, x86ms->oem_id,
+                  x86ms->oem_table_id);
+  return table;
+}

--- a/hw/i386/acpi-build.h
+++ b/hw/i386/acpi-build.h
@@ -8,4 +8,6 @@ extern const struct AcpiGenericAddress x86_nvdimm_acpi_dsmio;
 void acpi_setup(void);
 Object *acpi_get_i386_pci_host(void);
 
+GArray *acpi_build_madt_standalone(MachineState *machine);
+
 #endif

--- a/hw/i386/pc_piix.c
+++ b/hw/i386/pc_piix.c
@@ -376,13 +376,19 @@ static void pc_init1(MachineState *machine, const char *pci_type)
     }
 
 #if defined(CONFIG_IGVM)
-    /* Apply guest state from IGVM if supplied */
-    if (x86ms->igvm) {
+    MachineState *ms = MACHINE(x86ms);
+
+    GArray *madt = acpi_build_madt_standalone(ms);
+
+    /* Apply guest state from IGVM if supplied and provide MADT to the
+     * guest via IGVM parameter.*/
+    if (x86ms->igvm && madt->len > 0) {
         if (IGVM_CFG_GET_CLASS(x86ms->igvm)
-                ->process(x86ms->igvm, machine->cgs, false, &error_fatal) < 0) {
+                ->process(x86ms->igvm, ms->cgs, madt, false, &error_fatal) < 0) {
             g_assert_not_reached();
         }
     }
+    g_array_free(madt, true);
 #endif
 }
 

--- a/hw/i386/pc_q35.c
+++ b/hw/i386/pc_q35.c
@@ -332,13 +332,19 @@ static void pc_q35_init(MachineState *machine)
     }
 
 #if defined(CONFIG_IGVM)
-    /* Apply guest state from IGVM if supplied */
-    if (x86ms->igvm) {
+    MachineState *ms = MACHINE(x86ms);
+
+    GArray *madt = acpi_build_madt_standalone(ms);
+
+    /* Apply guest state from IGVM if supplied and provide MADT to the
+     * guest via IGVM parameter.*/
+    if (x86ms->igvm && madt->len > 0) {
         if (IGVM_CFG_GET_CLASS(x86ms->igvm)
-                ->process(x86ms->igvm, machine->cgs, false, &error_fatal) < 0) {
+                ->process(x86ms->igvm, ms->cgs, madt, false, &error_fatal) < 0) {
             g_assert_not_reached();
         }
     }
+    g_array_free(madt, true);
 #endif
 
     if (pcms->svsm_virtio_mmio) {

--- a/include/system/igvm-cfg.h
+++ b/include/system/igvm-cfg.h
@@ -37,7 +37,7 @@ typedef struct IgvmCfgClass {
      *
      * Returns 0 for ok and -1 on error.
      */
-    int (*process)(IgvmCfg *cfg, ConfidentialGuestSupport *cgs,
+    int (*process)(IgvmCfg *cfg, ConfidentialGuestSupport *cgs, GArray *madt,
                    bool onlyVpContext, Error **errp);
 
 } IgvmCfgClass;

--- a/target/i386/sev.c
+++ b/target/i386/sev.c
@@ -1897,7 +1897,7 @@ static int sev_common_kvm_init(ConfidentialGuestSupport *cgs, Error **errp)
          */
         if (x86machine->igvm) {
             if (IGVM_CFG_GET_CLASS(x86machine->igvm)
-                    ->process(x86machine->igvm, machine->cgs, true, errp) ==
+                    ->process(x86machine->igvm, machine->cgs, NULL, true, errp) ==
                 -1) {
                 return -1;
             }


### PR DESCRIPTION
Supply the MADT via the IGVM parameter field when booting an IGVM file.
https://github.com/coconut-svsm/svsm/pull/858 will have SVSM pick up the MADT from there
and not rely on the fw_cfg anymore, which would allows us to drop commit https://github.com/coconut-svsm/qemu/commit/540ae1a8e80788e9da95c6967d9919da55d32e68 